### PR TITLE
Add isLoaded methods to FancyNpcs & FancyHolograms

### DIFF
--- a/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/HologramManager.java
+++ b/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/HologramManager.java
@@ -22,6 +22,8 @@ public interface HologramManager {
 
     void loadHolograms();
 
+    boolean isLoaded();
+
     void saveHolograms();
 
     void reloadHolograms();

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/HologramManagerImpl.java
@@ -166,6 +166,11 @@ public final class HologramManagerImpl implements HologramManager {
         if (hologramLoadLogging) FancyHolograms.get().getFancyLogger().info(String.format("Loaded %d holograms for all loaded worlds", allLoaded.size()));
     }
 
+    @Override
+    public boolean isLoaded() {
+        return isLoaded;
+    }
+
     public void loadHolograms(String world) {
         ImmutableList<Hologram> loaded = ImmutableList.copyOf(plugin.getHologramStorage().loadAll(world));
         loaded.forEach(this::addHologram);

--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/NpcManager.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/NpcManager.java
@@ -26,6 +26,8 @@ public interface NpcManager {
 
     void loadNpcs();
 
+    boolean isLoaded();
+
     void reloadNpcs();
 
 }

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
@@ -440,6 +440,11 @@ public class NpcManagerImpl implements NpcManager {
         this.setLoaded();
     }
 
+    @Override
+    public boolean isLoaded() {
+        return isLoaded;
+    }
+
     private void setLoaded() {
         isLoaded = true;
         new NpcsLoadedEvent().callEvent();


### PR DESCRIPTION
## 📋 Description

This PR adds a `isLoaded` method to the NpcManager and the HologramManager. This way it is possible for other plugins to easily check if the NPCs or holograms are currently loaded. This is useful as, for example, the NPCs are sometimes spawning after the server has started and players were already able to join.

I also created an issue some days ago and thought I could also contribute towards adding this feature.
- Closes #102 

## ✅ Checklist

- [x] My code follows the project's coding style and guidelines
- [x] I have tested my changes locally and they work as expected
- [x] ~I have added necessary documentation (if applicable)~
- [x] I have linked related issues using `Fixes #issue_number` or `Closes #issue_number`
- [x] I have rebased/merged with the latest `main` branch

## 🔍 Changes

- Added `isLoaded` method to NpcManager for FancyNpcs API
- Added `isLoaded` method to HologramManager for FancyHolograms API
- Added both methods to their respective interfaces

---

## 🧪 How to Test

Please describe how to manually test the changes made in this PR.

1. Make a plugin that uses the FancyNpcs or FancyHolograms API
2. Create a way to output the result of the `isLoaded` method (command, scheduler, etc)