### PR TITLE
Feature: Add ForceHidden boolean for Players for Npcs

### DIFF
--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/Npc.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/Npc.java
@@ -26,6 +26,7 @@ public abstract class Npc {
     private static final NpcAttribute INVISIBLE_ATTRIBUTE = FancyNpcsPlugin.get().getAttributeManager().getAttributeByName(EntityType.PLAYER, "invisible");
     private static final char[] localNameChars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'k', 'l', 'm', 'n', 'o', 'r'};
     protected final Map<UUID, Boolean> isTeamCreated = new ConcurrentHashMap<>();
+    protected final Map<UUID, Boolean> isForcedHidden = new ConcurrentHashMap<>();
     protected final Map<UUID, Boolean> isVisibleForPlayer = new ConcurrentHashMap<>();
     protected final Map<UUID, Boolean> isLookingAtPlayer = new ConcurrentHashMap<>();
     protected final Map<UUID, Long> lastPlayerInteraction = new ConcurrentHashMap<>();
@@ -107,7 +108,7 @@ public abstract class Npc {
 
     public void checkAndUpdateVisibility(Player player) {
         FancyNpcsPlugin.get().getNpcThread().submit(() -> {
-            boolean shouldBeVisible = shouldBeVisible(player);
+            boolean shouldBeVisible = !isForcedHidden.getOrDefault(player.getUniqueId(), false) && shouldBeVisible(player);
             boolean wasVisible = isVisibleForPlayer.getOrDefault(player.getUniqueId(), false);
 
             if (shouldBeVisible && !wasVisible) {
@@ -225,6 +226,10 @@ public abstract class Npc {
 
     public boolean isShownFor(Player player) {
         return isVisibleForPlayer.getOrDefault(player.getUniqueId(), false);
+    }
+
+    public Map<UUID, Boolean> getIsForcedHidden() {
+        return isForcedHidden;
     }
 
     public Map<UUID, Boolean> getIsLookingAtPlayer() {

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/listeners/PlayerQuitListener.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/listeners/PlayerQuitListener.java
@@ -19,6 +19,7 @@ public class PlayerQuitListener implements Listener {
         UUID uuid = event.getPlayer().getUniqueId();
         for (Npc npc : FancyNpcs.getInstance().getNpcManagerImpl().getAllNpcs()) {
             npc.getIsVisibleForPlayer().remove(uuid);
+            npc.getIsForcedHidden().remove(uuid);
             npc.getIsLookingAtPlayer().remove(uuid);
             npc.getIsTeamCreated().remove(uuid);
             new NpcStopLookingEvent(npc, event.getPlayer()).callEvent();


### PR DESCRIPTION
## 📋 Description

Currently it is not possible to continiously hide a Npc from the core Registry to a player.
Even when setting the visibility through the existent map it is only an indicator if the Npc should be re-spawned on the next iteration of the core loop.
That means even when cancelling the NpcSpawn event the whole check logic will be done first, resulting first in unnecessary "work" (which can be ignored when it is async anyways) but more important is annoying to achieve.

I don't exactly know if it will resolved but with the method of hiding through cancelling the NpcSpawn event I get that issue: BetonQuest/BetonQuest#3540

## ✅ Checklist

- [x] My code follows the project's coding style and guidelines
- [x] I have tested my changes locally and they work as expected
- [ ] I have added necessary documentation (if applicable)
- [ ] I have linked related issues using `Fixes #issue_number` or `Closes #issue_number`
- [ ] I have rebased/merged with the latest `main` branch

## 🔍 Changes

I've added the map to just skip the spawn process in the abstract Npc.
I also removed the setting of default values on Player join and replaced the re-setting to default on log out.
I doubt it will make a performance difference but it is "just better".

---

## 🧪 How to Test

Please describe how to manually test the changes made in this PR.

1. Make a test plugin which adds the UUID with the value true to the map
2. ...
3. Enjoy not having to cancel the event every tick
