### PR TITLE
Added visibility per npc feature

### DIFF
--- a/docs/src/fancynpcs/commands/npc.md
+++ b/docs/src/fancynpcs/commands/npc.md
@@ -147,6 +147,25 @@ Sets an attribute of the NPC.
 - **Syntax**:  `/npc attribute (npc) (set | list)`
 - **Permissions**: `fancynpcs.command.npc.attribute.(sub)`
 
+### Set visibility
+
+Controls who can see the NPC through visibility modes.
+
+- **Syntax**:  `/npc visibility (npc) (all | permission_required | manual)`
+- **Permissions**: `fancynpcs.command.npc.visibility`
+
+**Visibility Modes:**
+
+`all` - Everyone can see the NPC (default behavior).
+
+`permission_required` - Players need the permission `fancynpcs.npc.<npc_name>.see` to see this NPC.
+
+`manual` - Players must be manually added through the API to see the NPC. This mode is intended for API usage and allows developers to control visibility programmatically.
+
+!!!info
+The `manual` visibility mode provides the most granular control and is designed for advanced integrations. See the [API documentation](../api/getting-started.md) for details on managing manual visibility through code.
+!!!
+
 ## Npc location and rotation
 
 ### Turn npc to player

--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/Npc.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/Npc.java
@@ -76,6 +76,10 @@ public abstract class Npc {
      * @return True if the NPC should be visible for the player, otherwise false.
      */
     protected boolean shouldBeVisible(Player player) {
+        if (!data.getVisibility().canSee(player, this)) {
+            return false;
+        }
+
         int visibilityDistance = (data.getVisibilityDistance() > -1) ? data.getVisibilityDistance() : FancyNpcsPlugin.get().getFancyNpcConfig().getVisibilityDistance();
 
         if (visibilityDistance == 0) {
@@ -125,6 +129,12 @@ public abstract class Npc {
                 remove(player);
             }
         });
+    }
+
+    public void checkAndUpdateVisibilityForAll() {
+        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+            checkAndUpdateVisibility(onlinePlayer);
+        }
     }
 
     public abstract void lookAt(Player player, Location location);
@@ -218,6 +228,10 @@ public abstract class Npc {
 
     public Map<UUID, Boolean> getIsVisibleForPlayer() {
         return isVisibleForPlayer;
+    }
+
+    public boolean isShownFor(Player player) {
+        return isVisibleForPlayer.getOrDefault(player.getUniqueId(), false);
     }
 
     public Map<UUID, Boolean> getIsLookingAtPlayer() {

--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/NpcData.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/NpcData.java
@@ -2,6 +2,7 @@ package de.oliver.fancynpcs.api;
 
 import de.oliver.fancynpcs.api.actions.ActionTrigger;
 import de.oliver.fancynpcs.api.actions.NpcAction;
+import de.oliver.fancynpcs.api.data.property.NpcVisibility;
 import de.oliver.fancynpcs.api.skins.SkinData;
 import de.oliver.fancynpcs.api.utils.NpcEquipmentSlot;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -41,6 +42,7 @@ public class NpcData {
     private float scale;
     private int visibilityDistance;
     private Map<NpcAttribute, String> attributes;
+    private NpcVisibility visibility;
     private boolean isDirty;
 
     public NpcData(
@@ -118,6 +120,7 @@ public class NpcData {
         this.equipment = new ConcurrentHashMap<>();
         this.attributes = new ConcurrentHashMap<>();
         this.mirrorSkin = false;
+        this.visibility = NpcVisibility.ALL;
         this.isDirty = true;
     }
 
@@ -396,6 +399,16 @@ public class NpcData {
 
     public NpcData setMirrorSkin(boolean mirrorSkin) {
         this.mirrorSkin = mirrorSkin;
+        isDirty = true;
+        return this;
+    }
+
+    public NpcVisibility getVisibility() {
+        return visibility == null ? NpcVisibility.ALL : visibility;
+    }
+
+    public NpcData setVisibility(NpcVisibility visibility) {
+        this.visibility = visibility;
         isDirty = true;
         return this;
     }

--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/data/property/NpcVisibility.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/data/property/NpcVisibility.java
@@ -1,0 +1,86 @@
+package de.oliver.fancynpcs.api.data.property;
+
+import com.google.common.collect.HashMultimap;
+import de.oliver.fancynpcs.api.Npc;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+public enum NpcVisibility {
+    /**
+     * Everybody can see an NPC.
+     */
+    ALL((player, npc) -> true),
+    /**
+     * The player needs permission to see a specific NPC.
+     */
+    PERMISSION_REQUIRED(
+        (player, npc) -> player.hasPermission("fancynpcs.npc." + npc.getData().getName() + ".see")
+    ),
+    /**
+     * The player needs to be added manually through the API
+     */
+    MANUAL(ManualNpcVisibility::canSee);
+
+    private final VisibilityPredicate predicate;
+
+    NpcVisibility(VisibilityPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    public static Optional<NpcVisibility> byString(String value) {
+        return Arrays.stream(NpcVisibility.values())
+            .filter(visibility -> visibility.toString().equalsIgnoreCase(value))
+            .findFirst();
+    }
+
+    public boolean canSee(Player player, Npc npc) {
+        return this.predicate.canSee(player, npc);
+    }
+
+    @FunctionalInterface
+    public interface VisibilityPredicate {
+        boolean canSee(Player player, Npc npc);
+    }
+
+    /**
+     * Handling of NpcVisibility.MANUAL
+     */
+    public static class ManualNpcVisibility {
+        private static final HashMultimap<String, UUID> distantViewers = HashMultimap.create();
+
+        public static boolean canSee(Player player, Npc npc) {
+            return npc.isShownFor(player) || distantViewers.containsEntry(npc.getData().getName(), player.getUniqueId());
+        }
+
+        public static void addDistantViewer(Npc npc, UUID uuid) {
+            addDistantViewer(npc.getData().getName(), uuid);
+        }
+
+        public static void addDistantViewer(String npcName, UUID uuid) {
+            distantViewers.put(npcName, uuid);
+        }
+
+        public static void removeDistantViewer(Npc npc, UUID uuid) {
+            removeDistantViewer(npc.getData().getName(), uuid);
+        }
+
+        public static void removeDistantViewer(String npcName, UUID uuid) {
+            distantViewers.remove(npcName, uuid);
+        }
+
+        public static void remove(Npc npc) {
+            remove(npc.getData().getName());
+        }
+
+        public static void remove(String npcName) {
+            distantViewers.removeAll(npcName);
+        }
+
+        public static void clear() {
+            distantViewers.clear();
+        }
+    }
+}

--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/events/NpcModifyEvent.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/events/NpcModifyEvent.java
@@ -86,6 +86,7 @@ public class NpcModifyEvent extends Event implements Cancellable {
         GLOWING_COLOR,
         INTERACTION_COOLDOWN,
         SCALE,
+        VISIBILITY,
         VISIBILITY_DISTANCE,
         LOCATION,
         MIRROR_SKIN,

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
@@ -9,6 +9,7 @@ import de.oliver.fancynpcs.api.NpcData;
 import de.oliver.fancynpcs.api.NpcManager;
 import de.oliver.fancynpcs.api.actions.ActionTrigger;
 import de.oliver.fancynpcs.api.actions.NpcAction;
+import de.oliver.fancynpcs.api.data.property.NpcVisibility;
 import de.oliver.fancynpcs.api.events.NpcsLoadedEvent;
 import de.oliver.fancynpcs.api.skins.SkinData;
 import de.oliver.fancynpcs.api.skins.SkinLoadException;
@@ -179,6 +180,7 @@ public class NpcManagerImpl implements NpcManager {
             npcConfig.set("npcs." + data.getId() + ".interactionCooldown", data.getInteractionCooldown());
             npcConfig.set("npcs." + data.getId() + ".scale", data.getScale());
             npcConfig.set("npcs." + data.getId() + ".visibility_distance", data.getVisibilityDistance());
+            npcConfig.set("npcs." + data.getId() + ".visibility", data.getVisibility().name());
 
             if (data.getSkinData() != null) {
                 npcConfig.set("npcs." + data.getId() + ".skin.identifier", data.getSkinData().getIdentifier());
@@ -380,6 +382,8 @@ public class NpcManagerImpl implements NpcManager {
             float interactionCooldown = (float) npcConfig.getDouble("npcs." + id + ".interactionCooldown", 0);
             float scale = (float) npcConfig.getDouble("npcs." + id + ".scale", 1);
             int visibilityDistance = npcConfig.getInt("npcs." + id + ".visibility_distance", -1);
+            String visibilityStr = npcConfig.getString("npcs." + id + ".visibility", "ALL");
+            NpcVisibility visibility = NpcVisibility.byString(visibilityStr).orElse(NpcVisibility.ALL);
 
             Map<NpcAttribute, String> attributes = new HashMap<>();
             if (npcConfig.isConfigurationSection("npcs." + id + ".attributes")) {
@@ -434,6 +438,7 @@ public class NpcManagerImpl implements NpcManager {
                 }
             }
 
+            npc.getData().setVisibility(visibility);
             npc.create();
             registerNpc(npc);
         }

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/CloudCommandManager.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/CloudCommandManager.java
@@ -9,6 +9,7 @@ import de.oliver.fancynpcs.commands.arguments.LocationArgument;
 import de.oliver.fancynpcs.commands.arguments.NpcArgument;
 import de.oliver.fancynpcs.commands.exceptions.ReplyingParseException;
 import de.oliver.fancynpcs.commands.npc.*;
+import de.oliver.fancynpcs.api.data.property.NpcVisibility;
 import de.oliver.fancynpcs.utils.GlowingColor;
 import io.leangen.geantyref.TypeToken;
 import org.bukkit.Bukkit;
@@ -129,6 +130,8 @@ public final class CloudCommandManager {
                 translationKey = "command_invalid_entity_type";
             else if (exceptionContext.exception().enumClass() == GlowingColor.class)
                 translationKey = "command_invalid_glowing_color";
+            else if (exceptionContext.exception().enumClass() == NpcVisibility.class)
+                translationKey = "command_invalid_npc_visibility";
             // Sending error message to the sender. In case no specialized message has been found, a generic one is used instead.
             translator.translate(translationKey)
                     .replaceStripped("input", exceptionContext.exception().input())
@@ -194,6 +197,7 @@ public final class CloudCommandManager {
         annotationParser.parse(TypeCMD.INSTANCE);
         annotationParser.parse(ActionCMD.INSTANCE);
         annotationParser.parse(VisibilityDistanceCMD.INSTANCE);
+        annotationParser.parse(VisibilityCMD.INSTANCE);
 
         if (FancyNpcs.ENABLE_DEBUG_MODE_FEATURE_FLAG.isEnabled()) {
             annotationParser.parse(FancyNpcsDebugCMD.INSTANCE);

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/VisibilityCMD.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/VisibilityCMD.java
@@ -1,0 +1,39 @@
+package de.oliver.fancynpcs.commands.npc;
+
+import de.oliver.fancylib.translations.Translator;
+import de.oliver.fancynpcs.FancyNpcs;
+import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.data.property.NpcVisibility;
+import de.oliver.fancynpcs.api.events.NpcModifyEvent;
+import org.bukkit.command.CommandSender;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum VisibilityCMD {
+    INSTANCE;
+
+    private final Translator translator = FancyNpcs.getInstance().getTranslator();
+
+    @Command("npc visibility <npc> <visibility>")
+    @Permission("fancynpcs.command.npc.visibility")
+    public void onVisibility(
+            final @NotNull CommandSender sender,
+            final @NotNull Npc npc,
+            final @NotNull NpcVisibility visibility
+    ) {
+        if (new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.VISIBILITY, visibility, sender).callEvent()) {
+            npc.getData().setVisibility(visibility);
+
+            npc.checkAndUpdateVisibilityForAll();
+
+            translator.translate("npc_visibility_set")
+                    .replace("npc", npc.getData().getName())
+                    .replace("visibility", visibility.toString())
+                    .send(sender);
+        } else {
+            translator.translate("command_npc_modification_cancelled").send(sender);
+        }
+    }
+}

--- a/plugins/fancynpcs/src/main/resources/languages/default.yml
+++ b/plugins/fancynpcs/src/main/resources/languages/default.yml
@@ -74,6 +74,7 @@ messages:
   command_invalid_location: "<dark_gray>› {errorColor}Argument {warningColor}{input}{errorColor} is not a valid location."
   command_invalid_world: "<dark_gray>› {errorColor}World named {warningColor}{input}{errorColor} does not exist or is not loaded."
   command_invalid_glowing_color: "<dark_gray>› {errorColor}Argument named {warningColor}{input}{errorColor} is not a valid glowing color."
+  command_invalid_npc_visibility: "<dark_gray>› {errorColor}Argument named {warningColor}{input}{errorColor} is not a valid visibility type."
   command_invalid_list_sort_type: "<dark_gray>› {errorColor}Argument named {warningColor}{input}{errorColor} is not a valid sort type."
   command_invalid_nearby_sort_type: "<dark_gray>› {errorColor}Argument named {warningColor}{input}{errorColor} is not a valid sort type."
   command_invalid_entity_type: "<dark_gray>› {errorColor}Argument named {warningColor}{input}{errorColor} is not a valid entity type."
@@ -130,6 +131,7 @@ messages:
     npc_turn_to_player: "<dark_gray>› <gray>Syntax: {primaryColor}/npc turn_to_player {secondaryColor}(npc) (state)"
     npc_turn_to_player_distance: "<dark_gray>› <gray>Syntax: {primaryColor}/npc turn_to_player_distance {secondaryColor}(npc) (state)"
     npc_type: "<dark_gray>› <gray>Syntax: {primaryColor}/npc type {secondaryColor}(npc) (type)"
+    npc_visibility: "<dark_gray>› <gray>Syntax: {primaryColor}/npc visibility {secondaryColor}(npc) (all | permission_required | manual)"
     npc_visibility_distance: "<dark_gray>› <gray>Syntax: {primaryColor}/npc visibility_distance {secondaryColor}(npc) (always_visible | default | not_visible | distance)"
 
   # Commands (fancynpcs)
@@ -185,6 +187,7 @@ messages:
     - "<dark_gray>› <hover:show_text:'<gray>Changes whether the NPC should turn to the player when in range.'>{primaryColor}/npc turn_to_player {secondaryColor}(npc) (state)"
     - "<dark_gray>› <hover:show_text:'<gray>Changes the distance at which the NPC should turn to the player.'>{primaryColor}/npc turn_to_player_distance {secondaryColor}(npc) (distance)"
     - "<dark_gray>› <hover:show_text:'<gray>Changes the type of the NPC.'>{primaryColor}/npc type {secondaryColor}(npc) (type)"
+    - "<dark_gray>› <hover:show_text:'<gray>Changes the visibility mode of the NPC. Controls who can see this NPC.'>{primaryColor}/npc visibility {secondaryColor}(npc) (all | permission_required | manual)"
     - "<dark_gray>› <hover:show_text:'<gray>Changes the visibility distance of the NPC.'>{primaryColor}/npc visibility_distance {secondaryColor}(npc) (default | distance | ...)"
 
   # Commands (npc action)
@@ -309,6 +312,9 @@ messages:
 
   # Commands (scale)
   npc_scale_set_success: "<dark_gray>› <gray>NPC {warningColor}{npc}<gray> has been scaled to {warningColor}{scale}<gray>."
+
+  # Commands (npc visibility)
+  npc_visibility_set: "<dark_gray>› <gray>NPC {warningColor}{npc}<gray> visibility has been set to {warningColor}{visibility}<gray>."
 
   # Commands (npc visibility_distance)
   npc_visibility_distance_set_value: "<dark_gray>› <gray>NPC {warningColor}{npc}<gray> is now visible from {warningColor}{distance}<gray> blocks."


### PR DESCRIPTION
Added visibility per npc feature from here: https://github.com/FancyInnovations/FancyPlugins/issues/112

Controls who can see the NPC through visibility modes.

- **Syntax**:  `/npc visibility (npc) (all | permission_required | manual)`
- **Permissions**: `fancynpcs.command.npc.visibility`

**Visibility Modes:**

`all` - Everyone can see the NPC (default behavior).

`permission_required` - Players need the permission `fancynpcs.npc.<npc_name>.see` to see this NPC.

`manual` - Players must be manually added through the API to see the NPC. This mode is intended for API usage and allows developers to control visibility programmatically.
