### PR TITLE
Added copy_to_clipboard action for FancyDialogs

### DIFF
--- a/libraries/packets/implementations/1_21_11/src/main/java/de/oliver/fancysitula/versions/v1_21_11/packets/ClientboundShowDialogPacketImpl.java
+++ b/libraries/packets/implementations/1_21_11/src/main/java/de/oliver/fancysitula/versions/v1_21_11/packets/ClientboundShowDialogPacketImpl.java
@@ -5,6 +5,7 @@ import de.oliver.fancysitula.api.dialogs.FS_Dialog;
 import de.oliver.fancysitula.api.dialogs.FS_DialogAction;
 import de.oliver.fancysitula.api.dialogs.actions.FS_CommonButtonData;
 import de.oliver.fancysitula.api.dialogs.actions.FS_DialogActionButton;
+import de.oliver.fancysitula.api.dialogs.actions.FS_DialogCopyToClipboardAction;
 import de.oliver.fancysitula.api.dialogs.actions.FS_DialogCustomAction;
 import de.oliver.fancysitula.api.dialogs.body.FS_DialogBody;
 import de.oliver.fancysitula.api.dialogs.body.FS_DialogItemBody;
@@ -27,8 +28,10 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.common.ClientboundShowDialogPacket;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.dialog.*;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.server.dialog.action.Action;
 import net.minecraft.server.dialog.action.CustomAll;
+import net.minecraft.server.dialog.action.StaticAction;
 import net.minecraft.server.dialog.body.DialogBody;
 import net.minecraft.server.dialog.body.ItemBody;
 import net.minecraft.server.dialog.body.PlainMessage;
@@ -241,7 +244,10 @@ public class ClientboundShowDialogPacketImpl extends FS_ClientboundShowDialogPac
         CommonButtonData buttonData = commonButtonDataToNms(actionButton.getButtonData());
 
         Action action = null;
-        if (actionButton.getAction() instanceof FS_DialogCustomAction customAction) {
+        if (actionButton.getAction() instanceof FS_DialogCopyToClipboardAction copyToClipboardAction) {
+            ClickEvent clickEvent = new ClickEvent.CopyToClipboard(copyToClipboardAction.getValue());
+            action = new StaticAction(clickEvent);
+        } else if (actionButton.getAction() instanceof FS_DialogCustomAction customAction) {
             Key idKey = Key.key("fancysitula", customAction.getId());
             Identifier idLocation = PaperAdventure.asVanilla(idKey);
 

--- a/libraries/packets/implementations/1_21_6/src/main/java/de/oliver/fancysitula/versions/v1_21_6/packets/ClientboundShowDialogPacketImpl.java
+++ b/libraries/packets/implementations/1_21_6/src/main/java/de/oliver/fancysitula/versions/v1_21_6/packets/ClientboundShowDialogPacketImpl.java
@@ -5,6 +5,7 @@ import de.oliver.fancysitula.api.dialogs.FS_Dialog;
 import de.oliver.fancysitula.api.dialogs.FS_DialogAction;
 import de.oliver.fancysitula.api.dialogs.actions.FS_CommonButtonData;
 import de.oliver.fancysitula.api.dialogs.actions.FS_DialogActionButton;
+import de.oliver.fancysitula.api.dialogs.actions.FS_DialogCopyToClipboardAction;
 import de.oliver.fancysitula.api.dialogs.actions.FS_DialogCustomAction;
 import de.oliver.fancysitula.api.dialogs.body.FS_DialogBody;
 import de.oliver.fancysitula.api.dialogs.body.FS_DialogItemBody;
@@ -27,8 +28,10 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.common.ClientboundShowDialogPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.dialog.*;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.server.dialog.action.Action;
 import net.minecraft.server.dialog.action.CustomAll;
+import net.minecraft.server.dialog.action.StaticAction;
 import net.minecraft.server.dialog.body.DialogBody;
 import net.minecraft.server.dialog.body.ItemBody;
 import net.minecraft.server.dialog.body.PlainMessage;
@@ -241,7 +244,10 @@ public class ClientboundShowDialogPacketImpl extends FS_ClientboundShowDialogPac
         CommonButtonData buttonData = commonButtonDataToNms(actionButton.getButtonData());
 
         Action action = null;
-        if (actionButton.getAction() instanceof FS_DialogCustomAction customAction) {
+        if (actionButton.getAction() instanceof FS_DialogCopyToClipboardAction copyToClipboardAction) {
+            ClickEvent clickEvent = new ClickEvent.CopyToClipboard(copyToClipboardAction.getValue());
+            action = new StaticAction(clickEvent);
+        } else if (actionButton.getAction() instanceof FS_DialogCustomAction customAction) {
             Key idKey = Key.key("fancysitula", customAction.getId());
             ResourceLocation idLocation = PaperAdventure.asVanilla(idKey);
 

--- a/libraries/packets/implementations/1_21_9/src/main/java/de/oliver/fancysitula/versions/v1_21_9/packets/ClientboundShowDialogPacketImpl.java
+++ b/libraries/packets/implementations/1_21_9/src/main/java/de/oliver/fancysitula/versions/v1_21_9/packets/ClientboundShowDialogPacketImpl.java
@@ -5,6 +5,7 @@ import de.oliver.fancysitula.api.dialogs.FS_Dialog;
 import de.oliver.fancysitula.api.dialogs.FS_DialogAction;
 import de.oliver.fancysitula.api.dialogs.actions.FS_CommonButtonData;
 import de.oliver.fancysitula.api.dialogs.actions.FS_DialogActionButton;
+import de.oliver.fancysitula.api.dialogs.actions.FS_DialogCopyToClipboardAction;
 import de.oliver.fancysitula.api.dialogs.actions.FS_DialogCustomAction;
 import de.oliver.fancysitula.api.dialogs.body.FS_DialogBody;
 import de.oliver.fancysitula.api.dialogs.body.FS_DialogItemBody;
@@ -27,8 +28,10 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.common.ClientboundShowDialogPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.dialog.*;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.server.dialog.action.Action;
 import net.minecraft.server.dialog.action.CustomAll;
+import net.minecraft.server.dialog.action.StaticAction;
 import net.minecraft.server.dialog.body.DialogBody;
 import net.minecraft.server.dialog.body.ItemBody;
 import net.minecraft.server.dialog.body.PlainMessage;
@@ -241,7 +244,10 @@ public class ClientboundShowDialogPacketImpl extends FS_ClientboundShowDialogPac
         CommonButtonData buttonData = commonButtonDataToNms(actionButton.getButtonData());
 
         Action action = null;
-        if (actionButton.getAction() instanceof FS_DialogCustomAction customAction) {
+        if (actionButton.getAction() instanceof FS_DialogCopyToClipboardAction copyToClipboardAction) {
+            ClickEvent clickEvent = new ClickEvent.CopyToClipboard(copyToClipboardAction.getValue());
+            action = new StaticAction(clickEvent);
+        } else if (actionButton.getAction() instanceof FS_DialogCustomAction customAction) {
             Key idKey = Key.key("fancysitula", customAction.getId());
             ResourceLocation idLocation = PaperAdventure.asVanilla(idKey);
 

--- a/libraries/packets/packets-api/src/main/java/de/oliver/fancysitula/api/dialogs/actions/FS_DialogCopyToClipboardAction.java
+++ b/libraries/packets/packets-api/src/main/java/de/oliver/fancysitula/api/dialogs/actions/FS_DialogCopyToClipboardAction.java
@@ -1,0 +1,18 @@
+package de.oliver.fancysitula.api.dialogs.actions;
+
+public class FS_DialogCopyToClipboardAction implements FS_DialogActionButtonAction {
+
+    private String value;
+
+    public FS_DialogCopyToClipboardAction(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/dialog/DialogImpl.java
+++ b/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/dialog/DialogImpl.java
@@ -14,6 +14,8 @@ import de.oliver.fancysitula.api.dialogs.FS_Dialog;
 import de.oliver.fancysitula.api.dialogs.FS_DialogAction;
 import de.oliver.fancysitula.api.dialogs.actions.FS_CommonButtonData;
 import de.oliver.fancysitula.api.dialogs.actions.FS_DialogActionButton;
+import de.oliver.fancysitula.api.dialogs.actions.FS_DialogActionButtonAction;
+import de.oliver.fancysitula.api.dialogs.actions.FS_DialogCopyToClipboardAction;
 import de.oliver.fancysitula.api.dialogs.actions.FS_DialogCustomAction;
 import de.oliver.fancysitula.api.dialogs.body.FS_DialogBody;
 import de.oliver.fancysitula.api.dialogs.body.FS_DialogTextBody;
@@ -94,19 +96,33 @@ public class DialogImpl extends Dialog {
 
         List<FS_DialogActionButton> actions = new ArrayList<>();
         for (DialogButton button : data.buttons()) {
+            FS_DialogActionButtonAction buttonAction;
+
+            if (button.actions().size() == 1 &&
+                button.actions().get(0).name().equals("copy_to_clipboard")) {
+                String text = ChatColorHandler.translate(
+                        button.actions().get(0).data(),
+                        player,
+                        ParserTypes.placeholder()
+                );
+                buttonAction = new FS_DialogCopyToClipboardAction(text);
+            } else {
+                buttonAction = new FS_DialogCustomAction(
+                        "fancydialogs_dialog_action",
+                        Map.of(
+                                "dialog_id", id,
+                                "button_id", button.id()
+                        )
+                );
+            }
+
             FS_DialogActionButton fsDialogActionButton = new FS_DialogActionButton(
                     new FS_CommonButtonData(
                             ChatColorHandler.translate(button.label(), player, ParserTypes.placeholder()),
                             ChatColorHandler.translate(button.tooltip(), player, ParserTypes.placeholder()),
                             150 // default button width
                     ),
-                    new FS_DialogCustomAction(
-                            "fancydialogs_dialog_action",
-                            Map.of(
-                                    "dialog_id", id,
-                                    "button_id", button.id()
-                            )
-                    )
+                    buttonAction
             );
             actions.add(fsDialogActionButton);
         }


### PR DESCRIPTION
Suggested here: https://discord.com/channels/1092507996166295644/1442647417710182470
Example use:
```json

    {
      "label": "<color:#1787ff>Copy Discord Link</color>",
      "tooltip": "<color:#1787ff>Click to copy Discord invite to clipboard!</color>",
      "actions": [
        {
          "name": "copy_to_clipboard",
          "data": "https://discord.gg/example"
        }
      ]
    },
```
