### PR TITLE
fancynpcs: fix skin identifiers being occasionally overridden

### DIFF
--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/skins/SkinManagerImpl.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/skins/SkinManagerImpl.java
@@ -183,8 +183,13 @@ public class SkinManagerImpl implements SkinManager, Listener {
                 }
             }
             if (id.equals(event.getId())) {
-                event.getSkin().setIdentifier(skin.getIdentifier());
-                npc.getData().setSkinData(event.getSkin());
+                final SkinData updatedSkin = new SkinData(
+                        skin.getIdentifier(),
+                        event.getSkin().getVariant(),
+                        event.getSkin().getTextureValue(),
+                        event.getSkin().getTextureSignature()
+                );
+                npc.getData().setSkinData(updatedSkin);
                 npc.removeForAll();
                 npc.spawnForAll();
                 FancyNpcs.getInstance().getFancyLogger().info("Updated skin for NPC: " + npc.getData().getName());


### PR DESCRIPTION
## 📋 Description

Problem originated from `SkinGeneratedEvent` listener which - upon generation from a placeholder value - would re-apply skins of *all* NPCs that resolved to the same username / uuid, with an updated `SkinData` object. This also covered updating the raw identifier, so all these NPCs would end up having their placeholder overridden as well.

## ✅ Checklist

- [x] My code follows the project's coding style and guidelines
- [x] I have tested my changes locally and they work as expected
- [x] I have added necessary documentation (if applicable)
- [x] I have linked related issues using `Fixes #issue_number` or `Closes #issue_number`
- [x] I have rebased/merged with the latest `main` branch

## 🔍 Changes

Please provide a brief summary of the changes made in this PR.

- Fixed a problem where skin identifiers being occasionally overridden when two placeholders returned the same username. 

---

## 🧪 How to Test

Please describe how to manually test the changes made in this PR.

1. Find two placeholders that return the same username.
2. Create two NPCs and set their skins to respective placeholders from step 1.
3. Run `/fancynpcs save`, then upon plugin reload (or skin refresh) they will **not** be replaced with the first placeholder that resolved to the same value. Prior this PR, both NPCs would be modified to use the same skin identifier.
