### PR TITLE
fancynpcs: Add BetterModel integration

### DIFF
--- a/plugins/fancynpcs/build.gradle.kts
+++ b/plugins/fancynpcs/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     compileOnly("me.clip:placeholderapi:2.11.6")
     compileOnly("com.intellectualsites.plotsquared:plotsquared-core:7.5.6")
     compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.3.14")
+    compileOnly("io.github.toxicity188:bettermodel:1.15.1")
 }
 
 paper {
@@ -87,6 +88,10 @@ paper {
             load = PaperPluginDescription.RelativeLoadOrder.BEFORE
         }
         register("PlotSquared") {
+            required = false
+            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+        }
+        register("BetterModel") {
             required = false
             load = PaperPluginDescription.RelativeLoadOrder.BEFORE
         }

--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/Npc.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/Npc.java
@@ -209,6 +209,8 @@ public abstract class Npc {
 
     public abstract int getEntityId();
 
+    public abstract org.bukkit.entity.Entity getEntity();
+
     public NpcData getData() {
         return data;
     }

--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/NpcData.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/NpcData.java
@@ -44,6 +44,8 @@ public class NpcData {
     private Map<NpcAttribute, String> attributes;
     private NpcVisibility visibility;
     private boolean isDirty;
+    private String modelName;
+    private float modelEyeHeight = -1;
 
     public NpcData(
             String id,
@@ -122,6 +124,7 @@ public class NpcData {
         this.mirrorSkin = false;
         this.visibility = NpcVisibility.ALL;
         this.isDirty = true;
+        this.modelName = null;
     }
 
     public String getId() {
@@ -419,5 +422,25 @@ public class NpcData {
 
     public void setDirty(boolean dirty) {
         isDirty = dirty;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public NpcData setModelName(String modelName) {
+        this.modelName = modelName;
+        isDirty = true;
+        return this;
+    }
+
+    public float getModelEyeHeight() {
+        return modelEyeHeight;
+    }
+
+    public NpcData setModelEyeHeight(float modelEyeHeight) {
+        this.modelEyeHeight = modelEyeHeight;
+        isDirty = true;
+        return this;
     }
 }

--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/actions/types/PlayAnimationAction.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/actions/types/PlayAnimationAction.java
@@ -1,0 +1,52 @@
+package de.oliver.fancynpcs.api.actions.types;
+
+import de.oliver.fancynpcs.api.actions.NpcAction;
+import de.oliver.fancynpcs.api.actions.executor.ActionExecutionContext;
+import org.jetbrains.annotations.NotNull;
+
+public class PlayAnimationAction extends NpcAction {
+
+    public PlayAnimationAction() {
+        super("play_animation", true);
+    }
+
+    @Override
+    public void execute(@NotNull ActionExecutionContext context, String value) {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+
+        if (context.getNpc() == null) {
+            return;
+        }
+
+        String modelName = context.getNpc().getData().getModelName();
+        if (modelName == null || modelName.isEmpty()) {
+            return;
+        }
+
+        try {
+            Class<?> hookClass = Class.forName("de.oliver.fancynpcs.bettermodel.BetterModelHook");
+            java.lang.reflect.Method isAvailable = hookClass.getMethod("isAvailable");
+            boolean available = (boolean) isAvailable.invoke(null);
+
+            if (!available) {
+                return;
+            }
+
+            Class<?> fancyNpcsClass = Class.forName("de.oliver.fancynpcs.FancyNpcs");
+            java.lang.reflect.Method getInstance = fancyNpcsClass.getMethod("getInstance");
+            Object instance = getInstance.invoke(null);
+
+            java.lang.reflect.Method getModelController = fancyNpcsClass.getMethod("getModelController");
+            Object controller = getModelController.invoke(instance);
+
+            if (controller != null) {
+                java.lang.reflect.Method playAnimation = controller.getClass().getMethod("playAnimation",
+                    de.oliver.fancynpcs.api.Npc.class, String.class);
+                playAnimation.invoke(controller, context.getNpc(), value);
+            }
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/events/NpcModifyEvent.java
+++ b/plugins/fancynpcs/fn-api/src/main/java/de/oliver/fancynpcs/api/events/NpcModifyEvent.java
@@ -115,6 +115,8 @@ public class NpcModifyEvent extends Event implements Cancellable {
         SERVER_COMMAND_SET,
         SERVER_COMMAND_REMOVE,
         SERVER_COMMAND_CLEAR,
-        SERVER_COMMAND_SEND_RANDOMLY
+        SERVER_COMMAND_SEND_RANDOMLY,
+        // Model.
+        MODEL
     }
 }

--- a/plugins/fancynpcs/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/Npc_1_20_1.java
+++ b/plugins/fancynpcs/implementation_1_20_1/src/main/java/de/oliver/fancynpcs/v1_20_1/Npc_1_20_1.java
@@ -384,6 +384,11 @@ public class Npc_1_20_1 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_20_2/src/main/java/de/oliver/fancynpcs/v1_20_2/Npc_1_20_2.java
+++ b/plugins/fancynpcs/implementation_1_20_2/src/main/java/de/oliver/fancynpcs/v1_20_2/Npc_1_20_2.java
@@ -379,6 +379,11 @@ public class Npc_1_20_2 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_20_4/src/main/java/de/oliver/fancynpcs/v1_20_4/Npc_1_20_4.java
+++ b/plugins/fancynpcs/implementation_1_20_4/src/main/java/de/oliver/fancynpcs/v1_20_4/Npc_1_20_4.java
@@ -378,6 +378,11 @@ public class Npc_1_20_4 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_20_6/src/main/java/de/oliver/fancynpcs/v1_20_6/Npc_1_20_6.java
+++ b/plugins/fancynpcs/implementation_1_20_6/src/main/java/de/oliver/fancynpcs/v1_20_6/Npc_1_20_6.java
@@ -393,6 +393,11 @@ public class Npc_1_20_6 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_21_1/src/main/java/de/oliver/fancynpcs/v1_21_1/Npc_1_21_1.java
+++ b/plugins/fancynpcs/implementation_1_21_1/src/main/java/de/oliver/fancynpcs/v1_21_1/Npc_1_21_1.java
@@ -408,6 +408,11 @@ public class Npc_1_21_1 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/Npc_1_21_11.java
+++ b/plugins/fancynpcs/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/Npc_1_21_11.java
@@ -471,6 +471,11 @@ public class Npc_1_21_11 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_21_3/src/main/java/de/oliver/fancynpcs/v1_21_3/Npc_1_21_3.java
+++ b/plugins/fancynpcs/implementation_1_21_3/src/main/java/de/oliver/fancynpcs/v1_21_3/Npc_1_21_3.java
@@ -427,6 +427,11 @@ public class Npc_1_21_3 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_21_4/src/main/java/de/oliver/fancynpcs/v1_21_4/Npc_1_21_4.java
+++ b/plugins/fancynpcs/implementation_1_21_4/src/main/java/de/oliver/fancynpcs/v1_21_4/Npc_1_21_4.java
@@ -428,6 +428,11 @@ public class Npc_1_21_4 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/Npc_1_21_5.java
+++ b/plugins/fancynpcs/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/Npc_1_21_5.java
@@ -437,6 +437,11 @@ public class Npc_1_21_5 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/Npc_1_21_6.java
+++ b/plugins/fancynpcs/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/Npc_1_21_6.java
@@ -460,6 +460,11 @@ public class Npc_1_21_6 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/Npc_1_21_9.java
+++ b/plugins/fancynpcs/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/Npc_1_21_9.java
@@ -471,6 +471,11 @@ public class Npc_1_21_9 extends Npc {
         return npc.getId();
     }
 
+    @Override
+    public org.bukkit.entity.Entity getEntity() {
+        return npc != null ? npc.getBukkitEntity() : null;
+    }
+
     public Entity getNpc() {
         return npc;
     }

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/FancyNpcs.java
@@ -30,6 +30,9 @@ import de.oliver.fancynpcs.api.Npc;
 import de.oliver.fancynpcs.api.NpcData;
 import de.oliver.fancynpcs.api.NpcManager;
 import de.oliver.fancynpcs.api.actions.types.*;
+import de.oliver.fancynpcs.bettermodel.BetterModelHook;
+import de.oliver.fancynpcs.bettermodel.ModelInteractionBridge;
+import de.oliver.fancynpcs.bettermodel.NpcModelController;
 import de.oliver.fancynpcs.api.skins.SkinData;
 import de.oliver.fancynpcs.api.skins.SkinManager;
 import de.oliver.fancynpcs.commands.CloudCommandManager;
@@ -97,6 +100,7 @@ public class FancyNpcs extends JavaPlugin implements FancyNpcsPlugin {
     private ActionManagerImpl actionManager;
     private VisibilityTracker visibilityTracker;
     private boolean usingPlotSquared;
+    private NpcModelController modelController;
 
     public FancyNpcs() {
         instance = this;
@@ -212,6 +216,12 @@ public class FancyNpcs extends JavaPlugin implements FancyNpcsPlugin {
         actionManager.registerAction(new BlockUntilDoneAction());
         actionManager.registerAction(new NeedPermissionAction());
         actionManager.registerAction(new PlaySoundAction());
+        actionManager.registerAction(new PlayAnimationAction());
+
+        if (BetterModelHook.isAvailable()) {
+            modelController = new NpcModelController();
+            fancyLogger.info("BetterModel integration enabled");
+        }
 
         skinManager = new SkinManagerImpl(new UUIDFileCache(), new SkinCacheFile(), new SkinCacheMemory(), MojangQueue.get(), MineSkinQueue.get());
         OldSkinCacheMigrator.migrate();
@@ -271,6 +281,10 @@ public class FancyNpcs extends JavaPlugin implements FancyNpcsPlugin {
         }
 
         pluginManager.registerEvents(new PlayerUseUnknownEntityListener(), instance);
+
+        if (BetterModelHook.isAvailable() && modelController != null) {
+            pluginManager.registerEvents(new ModelInteractionBridge(modelController), instance);
+        }
 
         if (PLAYER_NPCS_FEATURE_FLAG.isEnabled()) {
             pluginManager.registerEvents(new PlayerNpcsListener(), instance);
@@ -598,6 +612,10 @@ public class FancyNpcs extends JavaPlugin implements FancyNpcsPlugin {
 
     public boolean isUsingPlotSquared() {
         return usingPlotSquared;
+    }
+
+    public NpcModelController getModelController() {
+        return modelController;
     }
 
     @Override

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/NpcManagerImpl.java
@@ -213,6 +213,15 @@ public class NpcManagerImpl implements NpcManager {
                 }
             }
 
+            if (data.getModelName() != null) {
+                npcConfig.set("npcs." + data.getId() + ".model.name", data.getModelName());
+                if (data.getModelEyeHeight() >= 0) {
+                    npcConfig.set("npcs." + data.getId() + ".model.eyeHeight", data.getModelEyeHeight());
+                }
+            } else {
+                npcConfig.set("npcs." + data.getId() + ".model", null);
+            }
+
             npc.setDirty(false);
         }
 
@@ -436,6 +445,13 @@ public class NpcManagerImpl implements NpcManager {
                     ItemStack item = npcConfig.getItemStack("npcs." + id + ".equipment." + equipmentSlotStr);
                     npc.getData().addEquipment(equipmentSlot, item);
                 }
+            }
+
+            String modelName = npcConfig.getString("npcs." + id + ".model.name");
+            if (modelName != null && !modelName.isEmpty()) {
+                npc.getData().setModelName(modelName);
+                float eyeHeight = (float) npcConfig.getDouble("npcs." + id + ".model.eyeHeight", -1);
+                npc.getData().setModelEyeHeight(eyeHeight);
             }
 
             npc.getData().setVisibility(visibility);

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/bettermodel/BetterModelHook.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/bettermodel/BetterModelHook.java
@@ -1,0 +1,62 @@
+package de.oliver.fancynpcs.bettermodel;
+
+import kr.toxicity.model.api.BetterModel;
+import kr.toxicity.model.api.data.renderer.ModelRenderer;
+import kr.toxicity.model.api.tracker.EntityTrackerRegistry;
+import org.bukkit.entity.Entity;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+public final class BetterModelHook {
+
+    private static final boolean AVAILABLE;
+
+    static {
+        boolean found = false;
+        try {
+            Class.forName("kr.toxicity.model.api.BetterModel");
+            found = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        AVAILABLE = found;
+    }
+
+    private BetterModelHook() {
+    }
+
+    public static boolean isAvailable() {
+        return AVAILABLE;
+    }
+
+    public static Optional<ModelRenderer> getModel(String name) {
+        if (!AVAILABLE) {
+            return Optional.empty();
+        }
+        return BetterModel.model(name);
+    }
+
+    public static Optional<EntityTrackerRegistry> getRegistry(Entity entity) {
+        if (!AVAILABLE) {
+            return Optional.empty();
+        }
+        return BetterModel.registry(entity);
+    }
+
+    public static Set<String> getModelNames() {
+        if (!AVAILABLE) {
+            return Collections.emptySet();
+        }
+        return BetterModel.modelKeys();
+    }
+
+    public static Set<String> getAnimations(String modelName) {
+        if (!AVAILABLE) {
+            return Collections.emptySet();
+        }
+        return getModel(modelName)
+                .map(renderer -> renderer.animations().keySet())
+                .orElse(Collections.emptySet());
+    }
+}

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/bettermodel/ModelInteractionBridge.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/bettermodel/ModelInteractionBridge.java
@@ -1,0 +1,101 @@
+package de.oliver.fancynpcs.bettermodel;
+
+import de.oliver.fancynpcs.FancyNpcs;
+import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.actions.ActionTrigger;
+import de.oliver.fancynpcs.api.events.NpcModifyEvent;
+import de.oliver.fancynpcs.api.events.NpcRemoveEvent;
+import de.oliver.fancynpcs.api.events.NpcSpawnEvent;
+import de.oliver.fancynpcs.api.events.NpcsLoadedEvent;
+import kr.toxicity.model.api.event.ModelInteractEvent;
+import kr.toxicity.model.api.nms.ModelInteractionHand;
+import kr.toxicity.model.api.tracker.EntityTracker;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class ModelInteractionBridge implements Listener {
+
+    private final NpcModelController modelController;
+
+    public ModelInteractionBridge(NpcModelController modelController) {
+        this.modelController = modelController;
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onModelInteract(ModelInteractEvent event) {
+        Entity sourceEntity = event.getHitBox().source();
+        Npc npc = modelController.getNpcByEntity(sourceEntity);
+
+        if (npc == null) {
+            npc = FancyNpcs.getInstance().getNpcManager().getNpc(sourceEntity.getEntityId());
+        }
+
+        if (npc == null) {
+            return;
+        }
+
+        ActionTrigger trigger = event.getHand() == ModelInteractionHand.LEFT
+                ? ActionTrigger.LEFT_CLICK
+                : ActionTrigger.RIGHT_CLICK;
+
+        npc.interact(event.getPlayer(), trigger);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onNpcModify(NpcModifyEvent event) {
+        if (event.getModification() != NpcModifyEvent.NpcModification.LOCATION
+                && event.getModification() != NpcModifyEvent.NpcModification.ROTATION) {
+            return;
+        }
+
+        Npc npc = event.getNpc();
+        String modelName = npc.getData().getModelName();
+        if (modelName == null) {
+            return;
+        }
+
+        FancyNpcs.getInstance().getScheduler().runTaskLater(null, 1L, () -> {
+            modelController.removeModel(npc);
+            npc.getData().setModelName(modelName);
+            modelController.applyModel(npc, modelName);
+        });
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onNpcRemove(NpcRemoveEvent event) {
+        Npc npc = event.getNpc();
+        if (npc.getData().getModelName() != null) {
+            modelController.cleanupNpc(npc);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onNpcSpawn(NpcSpawnEvent event) {
+        Npc npc = event.getNpc();
+        String modelName = npc.getData().getModelName();
+
+        if (modelName == null) {
+            return;
+        }
+
+        FancyNpcs.getInstance().getScheduler().runTaskLater(null, 10L, () -> {
+            EntityTracker tracker = modelController.getTracker(npc);
+            if (tracker == null || tracker.isClosed()) {
+                modelController.applyModel(npc, modelName);
+            }
+            modelController.spawnForPlayer(npc, event.getPlayer());
+        });
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onNpcsLoaded(NpcsLoadedEvent event) {
+        for (Npc npc : FancyNpcs.getInstance().getNpcManager().getAllNpcs()) {
+            String modelName = npc.getData().getModelName();
+            if (modelName != null && !modelName.isEmpty()) {
+                modelController.applyModel(npc, modelName);
+            }
+        }
+    }
+}

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/bettermodel/NpcModelController.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/bettermodel/NpcModelController.java
@@ -1,0 +1,157 @@
+package de.oliver.fancynpcs.bettermodel;
+
+import de.oliver.fancynpcs.api.Npc;
+import kr.toxicity.model.api.animation.AnimationModifier;
+import kr.toxicity.model.api.data.renderer.ModelRenderer;
+import kr.toxicity.model.api.tracker.EntityHideOption;
+import kr.toxicity.model.api.tracker.EntityTracker;
+import kr.toxicity.model.api.tracker.EntityTrackerRegistry;
+import kr.toxicity.model.api.tracker.TrackerModifier;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NpcModelController {
+
+    private final Map<String, EntityTracker> trackers = new ConcurrentHashMap<>();
+    private final Map<Integer, Npc> entityIdToNpc = new ConcurrentHashMap<>();
+
+    public boolean applyModel(Npc npc, String modelName) {
+        if (!BetterModelHook.isAvailable()) {
+            return false;
+        }
+
+        Optional<ModelRenderer> modelOpt = BetterModelHook.getModel(modelName);
+        if (modelOpt.isEmpty()) {
+            return false;
+        }
+
+        removeModel(npc);
+
+        Entity entity = npc.getEntity();
+        if (entity == null) {
+            return false;
+        }
+
+        EntityTracker tracker = modelOpt.get().create(
+                entity,
+                TrackerModifier.builder()
+                        .sightTrace(true)
+                        .damageAnimation(true)
+                        .damageTint(true)
+                        .build()
+        );
+
+        tracker.hideOption(EntityHideOption.DEFAULT);
+
+        String npcId = npc.getData().getId();
+        trackers.put(npcId, tracker);
+        entityIdToNpc.put(npc.getEntityId(), npc);
+        npc.getData().setModelName(modelName);
+
+        EntityTrackerRegistry registry = tracker.registry();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            registry.spawn(player);
+        }
+
+        return true;
+    }
+
+    public void removeModel(Npc npc) {
+        if (!BetterModelHook.isAvailable()) {
+            return;
+        }
+
+        String npcId = npc.getData().getId();
+        EntityTracker tracker = trackers.remove(npcId);
+        entityIdToNpc.remove(npc.getEntityId());
+
+        if (tracker != null && !tracker.isClosed()) {
+            tracker.close();
+        }
+
+        npc.getData().setModelName(null);
+    }
+
+    public void playAnimation(Npc npc, String animationName) {
+        playAnimation(npc, animationName, AnimationModifier.DEFAULT_WITH_PLAY_ONCE);
+    }
+
+    public void playAnimation(Npc npc, String animationName, AnimationModifier modifier) {
+        if (!BetterModelHook.isAvailable()) {
+            return;
+        }
+
+        EntityTracker tracker = trackers.get(npc.getData().getId());
+        if (tracker != null && !tracker.isClosed()) {
+            tracker.animate(animationName, modifier);
+        }
+    }
+
+    public void spawnForPlayer(Npc npc, Player player) {
+        if (!BetterModelHook.isAvailable()) {
+            return;
+        }
+
+        String modelName = npc.getData().getModelName();
+        if (modelName == null) {
+            return;
+        }
+
+        String npcId = npc.getData().getId();
+        EntityTracker tracker = trackers.get(npcId);
+
+        if (tracker == null || tracker.isClosed()) {
+            Entity entity = npc.getEntity();
+            if (entity == null) {
+                return;
+            }
+
+            Optional<EntityTrackerRegistry> registryOpt = BetterModelHook.getRegistry(entity);
+            if (registryOpt.isEmpty()) {
+                applyModel(npc, modelName);
+                tracker = trackers.get(npcId);
+            } else {
+                tracker = registryOpt.get().first();
+                if (tracker != null) {
+                    trackers.put(npcId, tracker);
+                    entityIdToNpc.put(npc.getEntityId(), npc);
+                }
+            }
+        }
+
+        if (tracker != null && !tracker.isClosed()) {
+            tracker.markPlayerForSpawn(player);
+            tracker.registry().spawn(player);
+        }
+    }
+
+    public EntityTracker getTracker(Npc npc) {
+        return trackers.get(npc.getData().getId());
+    }
+
+    public Npc getNpcByEntityId(int entityId) {
+        return entityIdToNpc.get(entityId);
+    }
+
+    public Npc getNpcByEntity(Entity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return entityIdToNpc.get(entity.getEntityId());
+    }
+
+    public void cleanupNpc(Npc npc) {
+        String npcId = npc.getData().getId();
+        EntityTracker tracker = trackers.remove(npcId);
+        entityIdToNpc.remove(npc.getEntityId());
+
+        if (tracker != null && !tracker.isClosed()) {
+            tracker.close();
+        }
+    }
+}

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/CloudCommandManager.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/CloudCommandManager.java
@@ -10,6 +10,7 @@ import de.oliver.fancynpcs.commands.arguments.LocationArgument;
 import de.oliver.fancynpcs.commands.arguments.NpcArgument;
 import de.oliver.fancynpcs.commands.exceptions.ReplyingParseException;
 import de.oliver.fancynpcs.commands.npc.*;
+import de.oliver.fancynpcs.bettermodel.BetterModelHook;
 import de.oliver.fancynpcs.utils.GlowingColor;
 import io.leangen.geantyref.TypeToken;
 import org.bukkit.Bukkit;
@@ -205,6 +206,11 @@ public final class CloudCommandManager {
 
         if (Set.of("1.21", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11").contains(Bukkit.getMinecraftVersion())) {
             annotationParser.parse(ScaleCMD.INSTANCE);
+        }
+
+        if (BetterModelHook.isAvailable()) {
+            annotationParser.parse(ModelCMD.INSTANCE);
+            annotationParser.parse(AnimateCMD.INSTANCE);
         }
 
         return this;

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/AnimateCMD.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/AnimateCMD.java
@@ -1,0 +1,77 @@
+package de.oliver.fancynpcs.commands.npc;
+
+import de.oliver.fancylib.translations.Translator;
+import de.oliver.fancynpcs.FancyNpcs;
+import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.bettermodel.BetterModelHook;
+import org.bukkit.command.CommandSender;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public enum AnimateCMD {
+    INSTANCE;
+
+    private final Translator translator = FancyNpcs.getInstance().getTranslator();
+
+    @Command("npc animate <npc> <animation>")
+    @Permission("fancynpcs.command.npc.animate")
+    public void onAnimate(
+            final @NotNull CommandSender sender,
+            final @NotNull Npc npc,
+            final @NotNull @Argument(suggestions = "AnimateCMD/animation") String animation
+    ) {
+        if (!BetterModelHook.isAvailable()) {
+            translator.translate("bettermodel_not_available").send(sender);
+            return;
+        }
+
+        String modelName = npc.getData().getModelName();
+        if (modelName == null) {
+            translator.translate("npc_model_none").replace("npc", npc.getData().getName()).send(sender);
+            return;
+        }
+
+        Set<String> animations = BetterModelHook.getAnimations(modelName);
+        if (!animations.contains(animation)) {
+            translator.translate("animation_not_found")
+                    .replace("animation", animation)
+                    .replace("model", modelName)
+                    .send(sender);
+            return;
+        }
+
+        FancyNpcs.getInstance().getModelController().playAnimation(npc, animation);
+        translator.translate("npc_animation_played")
+                .replace("npc", npc.getData().getName())
+                .replace("animation", animation)
+                .send(sender);
+    }
+
+    @Suggestions("AnimateCMD/animation")
+    public List<String> suggestAnimation(final CommandContext<CommandSender> context, final CommandInput input) {
+        if (!BetterModelHook.isAvailable()) {
+            return List.of();
+        }
+
+        Npc npc = context.getOrDefault("npc", null);
+        if (npc == null) {
+            return List.of();
+        }
+
+        String modelName = npc.getData().getModelName();
+        if (modelName == null) {
+            return List.of();
+        }
+
+        return new ArrayList<>(BetterModelHook.getAnimations(modelName));
+    }
+}

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/ModelCMD.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/ModelCMD.java
@@ -1,0 +1,137 @@
+package de.oliver.fancynpcs.commands.npc;
+
+import de.oliver.fancylib.translations.Translator;
+import de.oliver.fancynpcs.FancyNpcs;
+import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.events.NpcModifyEvent;
+import de.oliver.fancynpcs.bettermodel.BetterModelHook;
+import org.bukkit.command.CommandSender;
+import org.incendo.cloud.annotations.Argument;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
+import org.incendo.cloud.annotations.suggestion.Suggestions;
+import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.context.CommandInput;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public enum ModelCMD {
+    INSTANCE;
+
+    private final Translator translator = FancyNpcs.getInstance().getTranslator();
+
+    @Command("npc model <npc>")
+    @Permission("fancynpcs.command.npc.model")
+    public void onModelInfo(
+            final @NotNull CommandSender sender,
+            final @NotNull Npc npc
+    ) {
+        if (!BetterModelHook.isAvailable()) {
+            translator.translate("bettermodel_not_available").send(sender);
+            return;
+        }
+
+        String currentModel = npc.getData().getModelName();
+        if (currentModel == null) {
+            translator.translate("npc_model_none").replace("npc", npc.getData().getName()).send(sender);
+        } else {
+            translator.translate("npc_model_info")
+                    .replace("npc", npc.getData().getName())
+                    .replace("model", currentModel)
+                    .send(sender);
+        }
+    }
+
+    @Command("npc model <npc> <model>")
+    @Permission("fancynpcs.command.npc.model")
+    public void onModelSet(
+            final @NotNull CommandSender sender,
+            final @NotNull Npc npc,
+            final @NotNull @Argument(value = "model", suggestions = "ModelCMD/model") String model
+    ) {
+        if (!BetterModelHook.isAvailable()) {
+            translator.translate("bettermodel_not_available").send(sender);
+            return;
+        }
+
+        if (model.equalsIgnoreCase("@none") || model.equalsIgnoreCase("none")) {
+            String currentModel = npc.getData().getModelName();
+            if (currentModel == null) {
+                translator.translate("npc_model_none").replace("npc", npc.getData().getName()).send(sender);
+                return;
+            }
+
+            if (new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.MODEL, null, sender).callEvent()) {
+                FancyNpcs.getInstance().getModelController().removeModel(npc);
+                npc.removeForAll();
+                npc.spawnForAll();
+                translator.translate("npc_model_removed").replace("npc", npc.getData().getName()).send(sender);
+            } else {
+                translator.translate("command_npc_modification_cancelled").send(sender);
+            }
+            return;
+        }
+
+        if (!BetterModelHook.getModelNames().contains(model)) {
+            translator.translate("model_not_found").replace("model", model).send(sender);
+            return;
+        }
+
+        if (new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.MODEL, model, sender).callEvent()) {
+            boolean success = FancyNpcs.getInstance().getModelController().applyModel(npc, model);
+            if (success) {
+                translator.translate("npc_model_set")
+                        .replace("npc", npc.getData().getName())
+                        .replace("model", model)
+                        .send(sender);
+            } else {
+                translator.translate("model_apply_failed").replace("model", model).send(sender);
+            }
+        } else {
+            translator.translate("command_npc_modification_cancelled").send(sender);
+        }
+    }
+
+    @Command("npc model <npc> eyeheight <height>")
+    @Permission("fancynpcs.command.npc.model")
+    public void onModelEyeHeight(
+            final @NotNull CommandSender sender,
+            final @NotNull Npc npc,
+            final float height
+    ) {
+        if (!BetterModelHook.isAvailable()) {
+            translator.translate("bettermodel_not_available").send(sender);
+            return;
+        }
+
+        String modelName = npc.getData().getModelName();
+        if (modelName == null) {
+            translator.translate("npc_model_none").replace("npc", npc.getData().getName()).send(sender);
+            return;
+        }
+
+        if (new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.MODEL, height, sender).callEvent()) {
+            npc.getData().setModelEyeHeight(height);
+            translator.translate("npc_model_eyeheight_set")
+                    .replace("npc", npc.getData().getName())
+                    .replace("height", String.valueOf(height))
+                    .send(sender);
+        } else {
+            translator.translate("command_npc_modification_cancelled").send(sender);
+        }
+    }
+
+    @Suggestions("ModelCMD/model")
+    public List<String> suggestModel(final CommandContext<CommandSender> context, final CommandInput input) {
+        if (!BetterModelHook.isAvailable()) {
+            return List.of();
+        }
+
+        List<String> suggestions = new ArrayList<>();
+        suggestions.add("@none");
+        suggestions.addAll(BetterModelHook.getModelNames());
+        return suggestions;
+    }
+}

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/ScaleCMD.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/ScaleCMD.java
@@ -21,6 +21,11 @@ public enum ScaleCMD {
             final @NotNull Npc npc,
             final float factor
     ) {
+        if (npc.getData().getModelName() != null) {
+            translator.translate("command_unsupported_model_npc").send(sender);
+            return;
+        }
+
         if (new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.SCALE, factor, sender).callEvent()) {
             npc.getData().setScale(factor);
             npc.updateForAll();

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/ShowInTabCMD.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/ShowInTabCMD.java
@@ -23,6 +23,11 @@ public enum ShowInTabCMD {
             final @NotNull Npc npc,
             final @Nullable Boolean state
     ) {
+        if (npc.getData().getModelName() != null) {
+            translator.translate("command_unsupported_model_npc").send(sender);
+            return;
+        }
+
         final boolean finalState = (state == null) ? !npc.getData().isShowInTab() : state;
         // Calling the event and updating the state if not cancelled.
         if (new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.SHOW_IN_TAB, finalState, sender).callEvent()) {

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/SkinCMD.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/SkinCMD.java
@@ -45,6 +45,11 @@ public enum SkinCMD {
             return;
         }
 
+        if (npc.getData().getModelName() != null) {
+            translator.translate("command_unsupported_model_npc").send(sender);
+            return;
+        }
+
         final boolean isMirror = skin.equalsIgnoreCase("@mirror");
         final boolean isNone = skin.equalsIgnoreCase("@none");
         if (isMirror) {

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/TypeCMD.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/commands/npc/TypeCMD.java
@@ -24,6 +24,11 @@ public enum TypeCMD {
             final @NotNull Npc npc,
             final @NotNull EntityType type
     ) {
+        if (npc.getData().getModelName() != null) {
+            translator.translate("command_unsupported_model_npc").send(sender);
+            return;
+        }
+
         // Calling the event and updating the type if not cancelled.
         if (new NpcModifyEvent(npc, NpcModifyEvent.NpcModification.TYPE, type, sender).callEvent()) {
             npc.getData().setType(type);

--- a/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/tracker/TurnToPlayerTracker.java
+++ b/plugins/fancynpcs/src/main/java/de/oliver/fancynpcs/tracker/TurnToPlayerTracker.java
@@ -39,20 +39,23 @@ public class TurnToPlayerTracker implements Runnable {
                 int effectiveTurnDistance = (npcTurnDistance == -1) ? defaultTurnToPlayerDistance : npcTurnDistance;
 
                 if (npcData.isTurnToPlayer() && distance < effectiveTurnDistance) {
-                    // Calculate the base eye height for the entity type
-                    double baseEyeHeight = getEntityEyeHeight(npcData.getType());
+                    double eyeHeight;
+                    if (npcData.getModelName() != null && npcData.getModelEyeHeight() >= 0) {
+                        eyeHeight = npcData.getModelEyeHeight();
+                    } else {
+                        eyeHeight = getEntityEyeHeight(npcData.getType()) * npcData.getScale();
+                    }
 
-                    // Adjust the NPC location Y coordinate based on the scale
                     Location adjustedNpcLocation = npcLocation.clone();
-                    adjustedNpcLocation.setY(npcLocation.getY() + (baseEyeHeight * npcData.getScale()));
+                    adjustedNpcLocation.setY(npcLocation.getY() + eyeHeight);
 
-                    // Calculate direction from adjusted NPC eye position to player eye position
                     Location playerEyeLocation = playerLocation.clone();
                     playerEyeLocation.setY(playerLocation.getY() + player.getEyeHeight());
 
                     Location newLoc = playerEyeLocation.clone();
                     newLoc.setDirection(newLoc.subtract(adjustedNpcLocation).toVector());
                     npc.lookAt(player, newLoc);
+
                     // Setting NPC to be looking at the player and getting the value previously stored (or not) inside a map.
                     Boolean wasPreviouslyLooking = npc.getIsLookingAtPlayer().put(player.getUniqueId(), true);
                     // Comparing the previous state with current state to prevent event from being called continuously.

--- a/plugins/fancynpcs/src/main/resources/languages/default.yml
+++ b/plugins/fancynpcs/src/main/resources/languages/default.yml
@@ -88,6 +88,7 @@ messages:
   command_invalid_interval: "<dark_gray>› {errorColor}Argument {warningColor}{input}{errorColor} is not a valid duration of time."
   command_invalid_enum_generic: "<dark_gray>› {errorColor}Argument {warningColor}{input}{errorColor} is not a valid {enum}."
   command_unsupported_npc_type: "<dark_gray>› {errorColor}This NPC type does not support this feature."
+  command_unsupported_model_npc: "<dark_gray>› {errorColor}This command is not available for NPCs with a model. Remove the model first with {warningColor}/npc model <npc> @none{errorColor}."
   command_input_contains_blocked_command: "<dark_gray>› {errorColor}This command is not allowed for use in interactions."
   command_npc_modification_cancelled: "<dark_gray>› {errorColor}NPC modification has been cancelled by the API."
 
@@ -368,3 +369,15 @@ messages:
   # Commands (npc center)
   npc_center_success: "<dark_gray>› <gray>NPC {warningColor}{npc}<gray> has been centered to {warningColor}{x}<gray>, {warningColor}{y}<gray>, {warningColor}{z}<gray>."
   npc_center_failure_no_location: "<dark_gray>› {errorColor}NPC {warningColor}{npc}{errorColor} has no valid location."
+
+  # Commands (npc model) - BetterModel Integration
+  bettermodel_not_available: "<dark_gray>› {errorColor}BetterModel is not installed or not enabled."
+  model_not_found: "<dark_gray>› {errorColor}Model {warningColor}{model}{errorColor} does not exist."
+  model_apply_failed: "<dark_gray>› {errorColor}Failed to apply model {warningColor}{model}{errorColor}."
+  npc_model_set: "<dark_gray>› <gray>NPC {warningColor}{npc}<gray> is now using model {warningColor}{model}<gray>."
+  npc_model_info: "<dark_gray>› <gray>NPC {warningColor}{npc}<gray> is using model {warningColor}{model}<gray>."
+  npc_model_removed: "<dark_gray>› <gray>Model has been removed from NPC {warningColor}{npc}<gray>."
+  npc_model_none: "<dark_gray>› {errorColor}NPC {warningColor}{npc}{errorColor} does not have a model assigned."
+  npc_model_eyeheight_set: "<dark_gray>› <gray>Eye height for NPC {warningColor}{npc}<gray> has been set to {warningColor}{height}<gray> blocks."
+  animation_not_found: "<dark_gray>› {errorColor}Animation {warningColor}{animation}{errorColor} does not exist for model {warningColor}{model}{errorColor}."
+  npc_animation_played: "<dark_gray>› <gray>Playing animation {warningColor}{animation}<gray> on NPC {warningColor}{npc}<gray>."


### PR DESCRIPTION
## Summary
- Add optional BetterModel support for rendering custom BlockBench models on NPCs
- New `/npc model` and `/npc animate` commands for model management
- Model persistence and automatic spawning/despawning with visibility tracking
- `play_animation` NPC action for triggering animations via interactions

## Features
- `/npc model <npc> <model>` - Apply or remove BetterModel models to NPCs
- `/npc model <npc> eyeheight <height>` - Set custom eye height for turn-to-player functionality
- `/npc animate <npc> <animation>` - Play model animations on NPCs
- Model interaction bridging for click events on model hitboxes
- Prevents incompatible commands (skin, type, scale, showInTab) on NPCs with models

## Technical Changes
- `BetterModelHook` - Runtime availability detection for BetterModel plugin
- `NpcModelController` - EntityTracker lifecycle management
- `ModelInteractionBridge` - Event handling for model interactions
- Added `getEntity()` abstract method to Npc API for model attachment
- Model data persistence in `npcs.yml`

## Test plan
- [ ] Install BetterModel and FancyNpcs on a test server
- [ ] Create an NPC and apply a model with `/npc model <npc> <model>`
- [ ] Verify model displays correctly and follows NPC visibility
- [ ] Test `/npc animate` command with available animations
- [ ] Verify turn-to-player works with custom eye height
- [ ] Test model removal with `/npc model <npc> @none`
- [ ] Verify model persistence after server restart
- [ ] Test model interaction (clicking on model hitbox triggers NPC actions)
- [ ] Confirm incompatible commands are blocked for model NPCs