### PR TITLE
fancydialogs: Add argument support to dialogs

### DIFF
--- a/plugins/fancydialogs/fd-api/src/main/java/com/fancyinnovations/fancydialogs/api/Dialog.java
+++ b/plugins/fancydialogs/fd-api/src/main/java/com/fancyinnovations/fancydialogs/api/Dialog.java
@@ -32,6 +32,15 @@ public abstract class Dialog {
     abstract public void open(Player player);
 
     /**
+     * Opens the dialog for the specified player with arguments.
+     * Arguments can be referenced in dialog content using {arg:0}, {arg:1}, etc.
+     *
+     * @param player the player to open the dialog for
+     * @param args   the arguments to pass to the dialog
+     */
+    abstract public void open(Player player, String... args);
+
+    /**
      * Closes the dialog for the specified player.
      *
      * @param player the player to close the dialog for

--- a/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/actions/defaultActions/OpenDialogDialogAction.java
+++ b/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/actions/defaultActions/OpenDialogDialogAction.java
@@ -18,13 +18,19 @@ public class OpenDialogDialogAction implements DialogAction {
             return;
         }
 
-        Dialog targetDialog = FancyDialogsPlugin.get().getDialogRegistry().get(data);
+        // Parse data as: dialogId [arg1] [arg2] ...
+        String[] parts = data.split(" ");
+        String dialogId = parts[0];
+        String[] args = new String[parts.length - 1];
+        System.arraycopy(parts, 1, args, 0, args.length);
+
+        Dialog targetDialog = FancyDialogsPlugin.get().getDialogRegistry().get(dialogId);
         if (targetDialog == null) {
-            FancyDialogsPlugin.get().getFancyLogger().warn("Dialog with ID '" + data + "' not found.");
+            FancyDialogsPlugin.get().getFancyLogger().warn("Dialog with ID '" + dialogId + "' not found.");
             return;
         }
 
-        targetDialog.open(player);
+        targetDialog.open(player, args);
     }
 
 }

--- a/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/commands/DialogCMD.java
+++ b/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/commands/DialogCMD.java
@@ -46,16 +46,19 @@ public final class DialogCMD {
     }
 
     @Command("dialog open <dialog>")
-    @Description("Opens a dialog (for a player) by its ID")
+    @Description("Opens a dialog (for a player) by its ID with optional arguments")
     @CommandPermission("fancydialogs.commands.dialog.open")
     public void open(
             BukkitCommandActor actor,
             Dialog dialog,
-            @Optional EntitySelector<Player> target
+            @Optional EntitySelector<Player> target,
+            @Optional String[] args
     ) {
+        String[] dialogArgs = args != null ? args : new String[0];
+
         if (target == null) {
             if (actor.isPlayer()) {
-                dialog.open(actor.asPlayer());
+                dialog.open(actor.asPlayer(), dialogArgs);
                 translator.translate("commands.dialog.open.self")
                         .replace("id", dialog.getId())
                         .send(actor.sender());
@@ -66,7 +69,7 @@ public final class DialogCMD {
             }
         } else {
             for (Player player : target) {
-                dialog.open(player);
+                dialog.open(player, dialogArgs);
             }
 
             Collection<String> players = target.stream()

--- a/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/fancynpcs/OpenDialogNpcAction.java
+++ b/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/fancynpcs/OpenDialogNpcAction.java
@@ -16,13 +16,23 @@ public class OpenDialogNpcAction extends NpcAction {
 
     @Override
     public void execute(@NotNull ActionExecutionContext context, @Nullable String value) {
-        Dialog dialog = FancyDialogsPlugin.get().getDialogRegistry().get(value);
-        if (dialog == null) {
-            FancyDialogsPlugin.get().getFancyLogger().warn("Dialog with ID '" + value + "' not found for NPC action 'open_dialog'.");
+        if (value == null || value.isEmpty()) {
             return;
         }
 
-        dialog.open(context.getPlayer());
+        // Parse value as: dialogId [arg1] [arg2] ...
+        String[] parts = value.split(" ");
+        String dialogId = parts[0];
+        String[] args = new String[parts.length - 1];
+        System.arraycopy(parts, 1, args, 0, args.length);
+
+        Dialog dialog = FancyDialogsPlugin.get().getDialogRegistry().get(dialogId);
+        if (dialog == null) {
+            FancyDialogsPlugin.get().getFancyLogger().warn("Dialog with ID '" + dialogId + "' not found for NPC action 'open_dialog'.");
+            return;
+        }
+
+        dialog.open(context.getPlayer(), args);
     }
 
     public void register() {


### PR DESCRIPTION
## Summary
- Add support for dynamic arguments in dialogs via `dialog.open(player, args)`
- Arguments can be referenced in dialog content using `{arg:0}`, `{arg:1}`, etc.
- Arguments work in title, body text, input labels/placeholders, button labels/tooltips, and clipboard actions
- Updated `/dialog open` command to accept optional arguments
- Updated `open_dialog` action and FancyNpcs integration to support arguments

## Test plan
- [ ] Open a dialog with arguments via command: `/dialog open <id> @s arg1 arg2`
- [ ] Verify `{arg:0}`, `{arg:1}` placeholders are replaced in all dialog elements
- [ ] Test FancyNpcs action with: `open_dialog myDialog arg1 arg2`
- [ ] Test `open_dialog` button action with arguments