### PR TITLE
Fixed custom variant support

### DIFF
--- a/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/CatAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/CatAttributes.java
@@ -26,7 +26,10 @@ public class CatAttributes {
                 "variant",
                 getCatVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.identifier().getPath())
+                        .map(id -> {
+                            Identifier identifier = id.identifier();
+                            return identifier.getNamespace().equals("minecraft") ? identifier.getPath() : identifier.toString();
+                        })
                         .toList(),
                 List.of(EntityType.CAT),
                 CatAttributes::setVariant
@@ -55,7 +58,7 @@ public class CatAttributes {
         Holder<CatVariant> variant = getCatVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.CAT_VARIANT,
-                        Identifier.withDefaultNamespace(value.toLowerCase())
+                        Identifier.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/ChickenAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/ChickenAttributes.java
@@ -25,7 +25,10 @@ public class ChickenAttributes {
                 "variant",
                 getChickenVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.identifier().getPath())
+                        .map(id -> {
+                            Identifier identifier = id.identifier();
+                            return identifier.getNamespace().equals("minecraft") ? identifier.getPath() : identifier.toString();
+                        })
                         .toList(),
                 List.of(EntityType.CHICKEN),
                 ChickenAttributes::setVariant
@@ -40,7 +43,7 @@ public class ChickenAttributes {
         Holder<ChickenVariant> variant = getChickenVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.CHICKEN_VARIANT,
-                        Identifier.withDefaultNamespace(value.toLowerCase())
+                        Identifier.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/CowAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/CowAttributes.java
@@ -25,7 +25,10 @@ public class CowAttributes {
                 "variant",
                 getCowVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.identifier().getPath())
+                        .map(id -> {
+                            Identifier identifier = id.identifier();
+                            return identifier.getNamespace().equals("minecraft") ? identifier.getPath() : identifier.toString();
+                        })
                         .toList(),
                 List.of(EntityType.COW),
                 CowAttributes::setVariant
@@ -40,7 +43,7 @@ public class CowAttributes {
         Holder<CowVariant> variant = getCowVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.COW_VARIANT,
-                        Identifier.withDefaultNamespace(value.toLowerCase())
+                        Identifier.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/FrogAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/FrogAttributes.java
@@ -25,7 +25,10 @@ public class FrogAttributes {
                 "variant",
                 getFrogVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.identifier().getPath())
+                        .map(id -> {
+                            Identifier identifier = id.identifier();
+                            return identifier.getNamespace().equals("minecraft") ? identifier.getPath() : identifier.toString();
+                        })
                         .toList(),
                 List.of(EntityType.FROG),
                 FrogAttributes::setVariant
@@ -40,7 +43,7 @@ public class FrogAttributes {
         Holder<FrogVariant> variant = getFrogVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.FROG_VARIANT,
-                        Identifier.withDefaultNamespace(value.toLowerCase())
+                        Identifier.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/PigAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/PigAttributes.java
@@ -27,7 +27,10 @@ public class PigAttributes {
                 "variant",
                 getPigVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.identifier().getPath())
+                        .map(id -> {
+                            Identifier identifier = id.identifier();
+                            return identifier.getNamespace().equals("minecraft") ? identifier.getPath() : identifier.toString();
+                        })
                         .toList(),
                 List.of(EntityType.PIG),
                 PigAttributes::setVariant
@@ -49,7 +52,7 @@ public class PigAttributes {
         Holder<PigVariant> variant = getPigVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.PIG_VARIANT,
-                        Identifier.withDefaultNamespace(value.toLowerCase())
+                        Identifier.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/WolfAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/attributes/WolfAttributes.java
@@ -40,7 +40,10 @@ public class WolfAttributes {
                 "variant",
                 getWolfVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.identifier().getPath())
+                        .map(id -> {
+                            Identifier identifier = id.identifier();
+                            return identifier.getNamespace().equals("minecraft") ? identifier.getPath() : identifier.toString();
+                        })
                         .toList(),
                 List.of(EntityType.WOLF),
                 WolfAttributes::setVariant

--- a/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/CatAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/CatAttributes.java
@@ -26,7 +26,10 @@ public class CatAttributes {
                 "variant",
                 getCatVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.CAT),
                 CatAttributes::setVariant
@@ -55,7 +58,7 @@ public class CatAttributes {
         Holder<CatVariant> variant = getCatVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.CAT_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/ChickenAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/ChickenAttributes.java
@@ -25,7 +25,10 @@ public class ChickenAttributes {
                 "variant",
                 getChickenVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.CHICKEN),
                 ChickenAttributes::setVariant
@@ -40,7 +43,7 @@ public class ChickenAttributes {
         Holder<ChickenVariant> variant = getChickenVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.CHICKEN_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/CowAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/CowAttributes.java
@@ -25,7 +25,10 @@ public class CowAttributes {
                 "variant",
                 getCowVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.COW),
                 CowAttributes::setVariant
@@ -40,7 +43,7 @@ public class CowAttributes {
         Holder<CowVariant> variant = getCowVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.COW_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/FrogAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/FrogAttributes.java
@@ -25,7 +25,10 @@ public class FrogAttributes {
                 "variant",
                 getFrogVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.FROG),
                 FrogAttributes::setVariant
@@ -40,7 +43,7 @@ public class FrogAttributes {
         Holder<FrogVariant> variant = getFrogVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.FROG_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/PigAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/PigAttributes.java
@@ -27,7 +27,10 @@ public class PigAttributes {
                 "variant",
                 getPigVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.PIG),
                 PigAttributes::setVariant
@@ -49,7 +52,7 @@ public class PigAttributes {
         Holder<PigVariant> variant = getPigVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.PIG_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/WolfAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/attributes/WolfAttributes.java
@@ -40,7 +40,10 @@ public class WolfAttributes {
                 "variant",
                 getWolfVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.WOLF),
                 WolfAttributes::setVariant

--- a/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/CatAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/CatAttributes.java
@@ -26,7 +26,10 @@ public class CatAttributes {
                 "variant",
                 getCatVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.CAT),
                 CatAttributes::setVariant
@@ -55,7 +58,7 @@ public class CatAttributes {
         Holder<CatVariant> variant = getCatVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.CAT_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/ChickenAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/ChickenAttributes.java
@@ -25,7 +25,10 @@ public class ChickenAttributes {
                 "variant",
                 getChickenVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.CHICKEN),
                 ChickenAttributes::setVariant
@@ -40,7 +43,7 @@ public class ChickenAttributes {
         Holder<ChickenVariant> variant = getChickenVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.CHICKEN_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/CowAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/CowAttributes.java
@@ -25,7 +25,10 @@ public class CowAttributes {
                 "variant",
                 getCowVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.COW),
                 CowAttributes::setVariant
@@ -40,7 +43,7 @@ public class CowAttributes {
         Holder<CowVariant> variant = getCowVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.COW_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/FrogAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/FrogAttributes.java
@@ -25,7 +25,10 @@ public class FrogAttributes {
                 "variant",
                 getFrogVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.FROG),
                 FrogAttributes::setVariant
@@ -40,7 +43,7 @@ public class FrogAttributes {
         Holder<FrogVariant> variant = getFrogVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.FROG_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/PigAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/PigAttributes.java
@@ -27,7 +27,10 @@ public class PigAttributes {
                 "variant",
                 getPigVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.PIG),
                 PigAttributes::setVariant
@@ -49,7 +52,7 @@ public class PigAttributes {
         Holder<PigVariant> variant = getPigVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.PIG_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/WolfAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/attributes/WolfAttributes.java
@@ -40,7 +40,10 @@ public class WolfAttributes {
                 "variant",
                 getWolfVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.WOLF),
                 WolfAttributes::setVariant

--- a/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/CatAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/CatAttributes.java
@@ -26,7 +26,10 @@ public class CatAttributes {
                 "variant",
                 getCatVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.CAT),
                 CatAttributes::setVariant
@@ -55,7 +58,7 @@ public class CatAttributes {
         Holder<CatVariant> variant = getCatVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.CAT_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/ChickenAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/ChickenAttributes.java
@@ -25,7 +25,10 @@ public class ChickenAttributes {
                 "variant",
                 getChickenVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.CHICKEN),
                 ChickenAttributes::setVariant
@@ -40,7 +43,7 @@ public class ChickenAttributes {
         Holder<ChickenVariant> variant = getChickenVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.CHICKEN_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/CowAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/CowAttributes.java
@@ -25,7 +25,10 @@ public class CowAttributes {
                 "variant",
                 getCowVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.COW),
                 CowAttributes::setVariant
@@ -40,7 +43,7 @@ public class CowAttributes {
         Holder<CowVariant> variant = getCowVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.COW_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/FrogAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/FrogAttributes.java
@@ -25,7 +25,10 @@ public class FrogAttributes {
                 "variant",
                 getFrogVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.FROG),
                 FrogAttributes::setVariant
@@ -40,7 +43,7 @@ public class FrogAttributes {
         Holder<FrogVariant> variant = getFrogVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.FROG_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/PigAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/PigAttributes.java
@@ -27,7 +27,10 @@ public class PigAttributes {
                 "variant",
                 getPigVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.PIG),
                 PigAttributes::setVariant
@@ -49,7 +52,7 @@ public class PigAttributes {
         Holder<PigVariant> variant = getPigVariantRegistry()
                 .get(ResourceKey.create(
                         Registries.PIG_VARIANT,
-                        ResourceLocation.withDefaultNamespace(value.toLowerCase())
+                        ResourceLocation.parse(value.toLowerCase())
                 ))
                 .orElseThrow();
 

--- a/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/WolfAttributes.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/attributes/WolfAttributes.java
@@ -40,7 +40,10 @@ public class WolfAttributes {
                 "variant",
                 getWolfVariantRegistry()
                         .listElementIds()
-                        .map(id -> id.location().getPath())
+                        .map(id -> {
+                            ResourceLocation location = id.location();
+                            return location.getNamespace().equals("minecraft") ? location.getPath() : location.toString();
+                        })
                         .toList(),
                 List.of(EntityType.WOLF),
                 WolfAttributes::setVariant


### PR DESCRIPTION
## 📋 Description
This PR resolves an issue that was stopping users from using entity variants that used identifiers other than 'minecraft'

## ✅ Checklist

- [x] My code follows the project's coding style and guidelines
- [x] I have tested my changes locally and they work as expected
- [x] I have added necessary documentation (if applicable)
- [x] I have linked related issues using `Fixes #issue_number` or `Closes #issue_number`
- [x] I have rebased/merged with the latest `main` branch

## 🔍 Changes

Updated attributes to use `Identifier#parse` instead of `Identifier#withDefaultNamespace`, the `parse` method supports custom namespaces and falls back to the 'minecraft' namespace. Tab-completion for the related commands will return vanilla 'minecraft' variants without a namespace and custom variants as a full identifier like `example:variant`

---

## 🧪 How to Test

Please describe how to manually test the changes made in this PR.

1. Add a custom variant to your server with a datapack/plugin
2. Spawn an npc that supports variants (eg. frog)
3. Set the npc's variant to your custom variant
