### PR TITLE
Add file-based language loading for FancyEconomy

### DIFF
--- a/plugins/fancyeconomy/src/main/java/com/fancyinnovations/fancyeconomy/FancyEconomy.java
+++ b/plugins/fancyeconomy/src/main/java/com/fancyinnovations/fancyeconomy/FancyEconomy.java
@@ -15,7 +15,6 @@ import de.oliver.fancylib.serverSoftware.schedulers.FoliaScheduler;
 import de.oliver.fancylib.translations.Language;
 import de.oliver.fancylib.translations.TextConfig;
 import de.oliver.fancylib.translations.Translator;
-import de.oliver.fancylib.translations.message.SimpleMessage;
 import de.oliver.fancylib.versionFetcher.MasterVersionFetcher;
 import de.oliver.fancylib.versionFetcher.VersionFetcher;
 import dev.jorel.commandapi.CommandAPI;
@@ -110,44 +109,13 @@ public class FancyEconomy extends JavaPlugin {
         TextConfig textConfig = new TextConfig("#E3CA66", "#35ad1d", "#81E366", "#E3CA66", "#E36666", "");
         translator = new Translator(textConfig);
 
-        Language lang = new Language("default", "default");
-        lang.addMessage("player-not-found", new SimpleMessage(textConfig, "<dark_gray>› {errorColor}Could not find target player: '{player}'"));
-        lang.addMessage("no-permissions", new SimpleMessage(textConfig, "<dark_gray>› {errorColor}You don't have permissions to execute this command"));
-        lang.addMessage("no-inventory-space", new SimpleMessage(textConfig, "<dark_gray>› {errorColor}You don't have enough space in your inventory"));
-
-        lang.addMessage("help-balance", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}/{currency} balance <gray>- Shows your balance"));
-        lang.addMessage("help-balance-others", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}/{currency} balance <player> <gray>- Shows a player's balance"));
-        lang.addMessage("help-pay", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}/{currency} pay <player> <amount> <gray>- Pays money to a certain player"));
-        lang.addMessage("help-withdraw", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}/{currency} withdraw <amount> <gray>- Withdraw a certain amount of money"));
-        lang.addMessage("help-top", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}/{currency} top <page> <gray>- Shows the richest players"));
-        lang.addMessage("help-set", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}/{currency} set <player> <amount> <gray>- Sets the balance of a certain player"));
-        lang.addMessage("help-add", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}/{currency} add <player> <amount> <gray>- Adds money to a certain player"));
-        lang.addMessage("help-remove", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}/{currency} remove <player> <amount> <gray>- Removes money to a certain player"));
-
-        lang.addMessage("your-balance", new SimpleMessage(textConfig, "<dark_gray>› <gray>Your balance: {primaryColor}{balance}"));
-        lang.addMessage("balance-others", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}{player}'s <gray>balance: {primaryColor}{balance}"));
-
-        lang.addMessage("cannot-pay-yourself", new SimpleMessage(textConfig, "<dark_gray>› {errorColor}You cannot pay yourself"));
-        lang.addMessage("not-enough-money", new SimpleMessage(textConfig, "<dark_gray>› {errorColor}Insufficient balance"));
-        lang.addMessage("paid-sender", new SimpleMessage(textConfig, "<dark_gray>› <gray>Successfully paid {primaryColor}{amount} <gray>to {primaryColor}{receiver}"));
-        lang.addMessage("paid-receiver", new SimpleMessage(textConfig, "<dark_gray>› <gray>Received {primaryColor}{amount} <gray>from {primaryColor}{sender}"));
-
-        lang.addMessage("not-withdrawable", new SimpleMessage(textConfig, "<dark_gray>› {errorColor}This currency is not withdrawable"));
-        lang.addMessage("min-withdrawable", new SimpleMessage(textConfig, "<dark_gray>› {errorColor}The minimum withdraw amount is: {primaryColor}{amount}"));
-        lang.addMessage("max-withdrawable", new SimpleMessage(textConfig, "<dark_gray>› {errorColor}The maximum withdraw amount is: {primaryColor}{amount}"));
-        lang.addMessage("withdraw-success", new SimpleMessage(textConfig, "<dark_gray>› <gray>Successfully withdraw {primaryColor}{amount}"));
-        lang.addMessage("deposit-note", new SimpleMessage(textConfig, "<dark_gray>› {primaryColor}+ {amount}"));
-
-        lang.addMessage("set-success", new SimpleMessage(textConfig, "<dark_gray>› <gray>Successfully set {primaryColor}{player}'s <gray>balance to {primaryColor}{amount}"));
-        lang.addMessage("add-success", new SimpleMessage(textConfig, "<dark_gray>› <gray>Successfully added {primaryColor}{amount} <gray>to {primaryColor}{player}"));
-        lang.addMessage("remove-success", new SimpleMessage(textConfig, "<dark_gray>› <gray>Successfully removed {primaryColor}{amount} <gray>from {primaryColor}{player}"));
-
-        lang.addMessage("balancetop-your-place", new SimpleMessage(textConfig, "<dark_gray>› <gray>Your place: {primaryColor}#{place}"));
-        lang.addMessage("balance-top-empty-page", new SimpleMessage(textConfig, "<dark_gray>› <gray>No data for this page"));
-
-        lang.addMessage("reloaded-config", new SimpleMessage(textConfig, "<dark_gray>› <gray>Successfully reloaded the config"));
-        lang.addMessage("currency-list", new SimpleMessage(textConfig, "{primaryColor}<b>List of all currencies:</b>"));
-        translator.setSelectedLanguage(lang);
+        translator.loadLanguages(getDataFolder().getAbsolutePath());
+        Language selectedLanguage = translator.getLanguages().stream()
+                .filter(language -> language.getLanguageCode().equalsIgnoreCase(config.getLanguage())
+                        || language.getLanguageName().equalsIgnoreCase(config.getLanguage()))
+                .findFirst()
+                .orElse(translator.getFallbackLanguage());
+        translator.setSelectedLanguage(selectedLanguage);
 
         database = config.getDatabase();
         if (database == null) {

--- a/plugins/fancyeconomy/src/main/java/com/fancyinnovations/fancyeconomy/FancyEconomyConfig.java
+++ b/plugins/fancyeconomy/src/main/java/com/fancyinnovations/fancyeconomy/FancyEconomyConfig.java
@@ -28,6 +28,7 @@ public class FancyEconomyConfig {
     private String postgresqlUsername;
     private String postgresqlPassword;
     private String sqliteFile;
+    private String language;
 
     private boolean useShortFormat;
     private double minWithdrawAmount;
@@ -61,6 +62,12 @@ public class FancyEconomyConfig {
 
         sqliteFile = (String) ConfigHelper.getOrDefault(config, "database.sqlite.file_path", "database.db");
         sqliteFile = "plugins/FancyEconomy/" + sqliteFile;
+
+        /*
+            Translations
+         */
+        language = (String) ConfigHelper.getOrDefault(config, "language", "default");
+
 
 
         /*
@@ -102,6 +109,10 @@ public class FancyEconomyConfig {
         }
 
         FancyEconomy.getInstance().saveConfig();
+    }
+
+    public String getLanguage() {
+        return language;
     }
 
     public boolean useShortFormat() {

--- a/plugins/fancyeconomy/src/main/resources/languages/default.yml
+++ b/plugins/fancyeconomy/src/main/resources/languages/default.yml
@@ -1,0 +1,38 @@
+language_name: default
+messages:
+  player-not-found: "<dark_gray>› {errorColor}Could not find target player: '{player}'"
+  no-permissions: "<dark_gray>› {errorColor}You don't have permissions to execute this command"
+  no-inventory-space: "<dark_gray>› {errorColor}You don't have enough space in your inventory"
+
+  help-balance: "<dark_gray>› {primaryColor}/{currency} balance <gray>- Shows your balance"
+  help-balance-others: "<dark_gray>› {primaryColor}/{currency} balance <player> <gray>- Shows a player's balance"
+  help-pay: "<dark_gray>› {primaryColor}/{currency} pay <player> <amount> <gray>- Pays money to a certain player"
+  help-withdraw: "<dark_gray>› {primaryColor}/{currency} withdraw <amount> <gray>- Withdraw a certain amount of money"
+  help-top: "<dark_gray>› {primaryColor}/{currency} top <page> <gray>- Shows the richest players"
+  help-set: "<dark_gray>› {primaryColor}/{currency} set <player> <amount> <gray>- Sets the balance of a certain player"
+  help-add: "<dark_gray>› {primaryColor}/{currency} add <player> <amount> <gray>- Adds money to a certain player"
+  help-remove: "<dark_gray>› {primaryColor}/{currency} remove <player> <amount> <gray>- Removes money to a certain player"
+
+  your-balance: "<dark_gray>› <gray>Your balance: {primaryColor}{balance}"
+  balance-others: "<dark_gray>› {primaryColor}{player}'s <gray>balance: {primaryColor}{balance}"
+
+  cannot-pay-yourself: "<dark_gray>› {errorColor}You cannot pay yourself"
+  not-enough-money: "<dark_gray>› {errorColor}Insufficient balance"
+  paid-sender: "<dark_gray>› <gray>Successfully paid {primaryColor}{amount} <gray>to {primaryColor}{receiver}"
+  paid-receiver: "<dark_gray>› <gray>Received {primaryColor}{amount} <gray>from {primaryColor}{sender}"
+
+  not-withdrawable: "<dark_gray>› {errorColor}This currency is not withdrawable"
+  min-withdrawable: "<dark_gray>› {errorColor}The minimum withdraw amount is: {primaryColor}{amount}"
+  max-withdrawable: "<dark_gray>› {errorColor}The maximum withdraw amount is: {primaryColor}{amount}"
+  withdraw-success: "<dark_gray>› <gray>Successfully withdraw {primaryColor}{amount}"
+  deposit-note: "<dark_gray>› {primaryColor}+ {amount}"
+
+  set-success: "<dark_gray>› <gray>Successfully set {primaryColor}{player}'s <gray>balance to {primaryColor}{amount}"
+  add-success: "<dark_gray>› <gray>Successfully added {primaryColor}{amount} <gray>to {primaryColor}{player}"
+  remove-success: "<dark_gray>› <gray>Successfully removed {primaryColor}{amount} <gray>from {primaryColor}{player}"
+
+  balancetop-your-place: "<dark_gray>› <gray>Your place: {primaryColor}#{place}"
+  balance-top-empty-page: "<dark_gray>› <gray>No data for this page"
+
+  reloaded-config: "<dark_gray>› <gray>Successfully reloaded the config"
+  currency-list: "{primaryColor}<b>List of all currencies:</b>"


### PR DESCRIPTION
## 📋 Description

FancyEconomy currently keeps its default command messages in code. Because of that, a fresh install does not generate any editable language file for server owners.

This PR moves the existing default messages into `languages/default.yml` and loads them through the existing `Translator` language flow already used in other Fancy plugins. It also adds a `language` config option so another language file can be selected without changing code.

## ✅ Checklist

* [x] My code follows the project's coding style and guidelines
* [x] I have tested my changes locally and they work as expected
* [x] I have added necessary documentation (if applicable)
* [ ] I have linked related issues using `Fixes #issue_number` or `Closes #issue_number`
* [x] I have rebased/merged with the latest `main` branch

## 🔍 Changes

* Moved FancyEconomy's hardcoded default messages to `src/main/resources/languages/default.yml`
* Changed FancyEconomy to load messages through the existing `Translator#loadLanguages` flow
* Added a `language` config value for selecting the active language file
* Kept the current default messages unchanged while making them editable after install

---

## 🧪 How to Test

1. Build FancyEconomy.
2. Install the built jar on a test server.
3. Start the server and check that `plugins/FancyEconomy/languages/default.yml` is created.
4. Edit one message in `default.yml`.
5. Restart the server or reload the plugin.
6. Run a FancyEconomy command and confirm the edited message is used.
