### PR TITLE
FancyHolograms: Add an option to refresh holograms on player's locale change

### DIFF
--- a/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
+++ b/plugins/fancyholograms-v2/api/src/main/java/de/oliver/fancyholograms/api/HologramConfiguration.java
@@ -82,4 +82,11 @@ public interface HologramConfiguration {
     default int getHologramUpdateInterval() {
         return 200;
     }
+
+    /**
+     * Returns whether holograms should be refreshed on player locale change.
+     *
+     * @return {@code true} if holograms should be refreshed on locale change, {@code false} otherwise.
+     */
+    boolean isRefreshHologramsOnLocaleChangeEnabled();
 }

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/FancyHologramsConfiguration.java
@@ -27,6 +27,7 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
     private static final String CONFIG_REGISTER_COMMANDS = "register_commands";
     private static final String CONFIG_UPDATE_VISIBILITY_INTERVAL = "update_visibility_interval";
     private static final String CONFIG_HOLOGRAM_UPDATE_INTERVAL = "performance.hologram_update_interval_ms";
+    private static final String CONFIG_REFRESH_HOLOGRAMS_ON_LOCALE_CHANGE = "refresh_holograms_on_locale_change";
     private static final String CONFIG_REPORT_ERRORS_TO_SENTRY = "report_errors_to_sentry";
     private static final String CONFIG_VERSION = "config_version";
     private static final Map<String, List<String>> CONFIG_COMMENTS = Map.ofEntries(
@@ -40,7 +41,8 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
             Map.entry(CONFIG_VISIBILITY_DISTANCE, List.of("The default visibility distance for holograms.")),
             Map.entry(CONFIG_REGISTER_COMMANDS, List.of("Whether the plugin should register its commands.")),
             Map.entry(CONFIG_UPDATE_VISIBILITY_INTERVAL, List.of("The interval at which hologram visibility is updated in ticks.")),
-            Map.entry(CONFIG_HOLOGRAM_UPDATE_INTERVAL, List.of("The interval at which text holograms refresh placeholder updates in milliseconds. Lower values are more responsive but use more CPU."))
+            Map.entry(CONFIG_HOLOGRAM_UPDATE_INTERVAL, List.of("The interval at which text holograms refresh placeholder updates in milliseconds. Lower values are more responsive but use more CPU.")),
+            Map.entry(CONFIG_REFRESH_HOLOGRAMS_ON_LOCALE_CHANGE, List.of("Whether the holograms will be refreshed for a player when they change their locale."))
     );
     /**
      * Indicates whether autosave is enabled.
@@ -84,6 +86,10 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
      * The interval at which text holograms refresh dynamic text updates.
      */
     private int hologramUpdateInterval;
+    /**
+     * Whether holograms should be refreshed on player locale change.
+     */
+    private boolean refreshHologramsOnLocaleChange;
 
     private void updateChecker(@NotNull FancyHolograms plugin, @NotNull FileConfiguration config) {
         final int latestVersion = 1;
@@ -152,6 +158,7 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
         registerCommands = (boolean) ConfigHelper.getOrDefault(config, CONFIG_REGISTER_COMMANDS, true);
         updateVisibilityInterval = (int) ConfigHelper.getOrDefault(config, CONFIG_UPDATE_VISIBILITY_INTERVAL, 20);
         hologramUpdateInterval = Math.max(10, (int) ConfigHelper.getOrDefault(config, CONFIG_HOLOGRAM_UPDATE_INTERVAL, 200));
+        refreshHologramsOnLocaleChange = (boolean) ConfigHelper.getOrDefault(config, CONFIG_REFRESH_HOLOGRAMS_ON_LOCALE_CHANGE, false);
 
         config.set(CONFIG_REPORT_ERRORS_TO_SENTRY, null);
     }
@@ -220,5 +227,10 @@ public final class FancyHologramsConfiguration implements HologramConfiguration 
     @Override
     public int getHologramUpdateInterval() {
         return hologramUpdateInterval;
+    }
+
+    @Override
+    public boolean isRefreshHologramsOnLocaleChangeEnabled() {
+        return refreshHologramsOnLocaleChange;
     }
 }

--- a/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/listeners/PlayerListener.java
+++ b/plugins/fancyholograms-v2/src/main/java/de/oliver/fancyholograms/listeners/PlayerListener.java
@@ -2,6 +2,8 @@ package de.oliver.fancyholograms.listeners;
 
 import de.oliver.fancyholograms.FancyHolograms;
 import de.oliver.fancyholograms.api.hologram.Hologram;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -101,6 +103,25 @@ public final class PlayerListener implements Listener {
                 }
             });
         }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerLocaleChange(@NotNull final PlayerLocaleChangeEvent event) {
+        if (!this.plugin.getHologramConfiguration().isRefreshHologramsOnLocaleChangeEnabled())
+            return;
+
+        Player player = event.getPlayer();
+
+        Bukkit.getScheduler().runTaskLater(this.plugin, () -> {
+            if (!player.isOnline())
+                return;
+
+            this.plugin.getHologramThread().submit(() -> {
+                for (final Hologram hologram : this.plugin.getHologramsManager().getHolograms()) {
+                    hologram.refreshHologram(player);
+                }
+            });
+        }, 1L);
     }
 
 }

--- a/plugins/fancyholograms/fh-api/src/main/java/com/fancyinnovations/fancyholograms/api/HologramConfiguration.java
+++ b/plugins/fancyholograms/fh-api/src/main/java/com/fancyinnovations/fancyholograms/api/HologramConfiguration.java
@@ -45,6 +45,13 @@ public interface HologramConfiguration {
     int getSpawnDelayOnJoin();
 
     /**
+     * Returns whether holograms should be refreshed on player locale change.
+     *
+     * @return Whether holograms should be refreshed on player locale change.
+     */
+    boolean isRefreshHologramsOnLocaleChangeEnabled();
+
+    /**
      * Returns whether the plugin should register its commands.
      *
      * @return {@code true} if the plugin should register its commands, {@code false} otherwise.

--- a/plugins/fancyholograms/src/main/java/com/fancyinnovations/fancyholograms/config/FHConfiguration.java
+++ b/plugins/fancyholograms/src/main/java/com/fancyinnovations/fancyholograms/config/FHConfiguration.java
@@ -16,6 +16,7 @@ public final class FHConfiguration implements HologramConfiguration {
     public static final String SAVE_ON_CHANGED_PATH = "settings.saving.save_on_changed";
     public static final String VISIBILITY_DISTANCE_PATH = "settings.visibility_distance";
     public static final String SPAWN_DELAY_ON_JOIN_PATH = "settings.spawn_delay_on_join_ms";
+    public static final String REFRESH_HOLOGRAMS_ON_LOCALE_CHANGE_PATH = "settings.refresh_holograms_on_locale_change";
 
     public static final String REGISTER_COMMANDS_PATH = "settings.register_commands";
 
@@ -96,6 +97,15 @@ public final class FHConfiguration implements HologramConfiguration {
                 300,
                 false,
                 Integer.class
+        ));
+
+        config.addField(new ConfigField<>(
+            REFRESH_HOLOGRAMS_ON_LOCALE_CHANGE_PATH,
+            "When enabled, holograms will be refreshed for a player when they change their locale.",
+            false,
+            false,
+            false,
+            Boolean.class
         ));
 
         config.addField(new ConfigField<>(
@@ -213,6 +223,11 @@ public final class FHConfiguration implements HologramConfiguration {
     @Override
     public int getSpawnDelayOnJoin() {
         return config.get(SPAWN_DELAY_ON_JOIN_PATH);
+    }
+
+    @Override
+    public boolean isRefreshHologramsOnLocaleChangeEnabled() {
+        return config.get(REFRESH_HOLOGRAMS_ON_LOCALE_CHANGE_PATH);
     }
 
     @Override

--- a/plugins/fancyholograms/src/main/java/com/fancyinnovations/fancyholograms/listeners/PlayerListener.java
+++ b/plugins/fancyholograms/src/main/java/com/fancyinnovations/fancyholograms/listeners/PlayerListener.java
@@ -2,6 +2,8 @@ package com.fancyinnovations.fancyholograms.listeners;
 
 import com.fancyinnovations.fancyholograms.api.hologram.Hologram;
 import com.fancyinnovations.fancyholograms.main.FancyHologramsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -111,6 +113,25 @@ public final class PlayerListener implements Listener {
                 });
             }
         }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerLocaleChange(@NotNull final PlayerLocaleChangeEvent event) {
+        if (!this.plugin.getFHConfiguration().isRefreshHologramsOnLocaleChangeEnabled())
+            return;
+
+        Player player = event.getPlayer();
+
+        Bukkit.getScheduler().runTaskLater(this.plugin, () -> {
+            if (!player.isOnline())
+                return;
+
+            this.plugin.getHologramThread().submit(() -> {
+                for (final Hologram hologram : this.plugin.getRegistry().getAll()) {
+                    this.plugin.getController().refreshHologram(hologram, player);
+                }
+            });
+        }, 1L);
     }
 
 }


### PR DESCRIPTION
## 📋 Description

Adds an option to refresh holograms a player when their locale changes.

I display some server-side content that depends on player's client locale. Currently, I have to use the refresh interval, but this has two downsides: not seamless due to delay, and redundant updates for static holograms.

## ✅ Checklist

- [x] My code follows the project's coding style and guidelines
- [x] I have tested my changes locally and they work as expected
- [x] I have added necessary documentation (if applicable)
- [ ] I have linked related issues using `Fixes #issue_number` or `Closes #issue_number`
- [x] I have rebased/merged with the latest `main` branch

## 🔍 Changes

Please provide a brief summary of the changes made in this PR.

- Added a new config option and an event listener.

---

## 🧪 How to Test

Please describe how to manually test the changes made in this PR.

1. Enable config option.
2. Have static hologram with some dynamic placeholder.
3. While observing a hologram, change locale on the client.
4. Observe hologram refresh.
