### PR TITLE
Fix NPC not showing for players without skin when using @mirror

### DIFF
--- a/plugins/fancynpcs/src/main/java/com/fancyinnovations/fancynpcs/npc/NpcImpl.java
+++ b/plugins/fancynpcs/src/main/java/com/fancyinnovations/fancynpcs/npc/NpcImpl.java
@@ -243,6 +243,15 @@ public class NpcImpl extends Npc {
             profile = new FS_GameProfile(fsEntity.getUuid(), localName, properties);
         } else {
             profile = FS_GameProfile.fromBukkit(viewer.getPlayerProfile());
+            if (!profile.getProperties().containsKey("textures")) {
+                if (data.getSkinData() != null && data.getSkinData().hasTexture()) {
+                    profile.getProperties().put("textures", new FS_GameProfile.Property(
+                            "textures",
+                            data.getSkinData().getTextureValue(),
+                            data.getSkinData().getTextureSignature()
+                    ));
+                }
+            }
             profile.setUUID(fsEntity.getUuid());
             profile.setName(localName);
         }


### PR DESCRIPTION
## 📋 Description

When an NPC uses the @mirror skin setting and is viewed by an offline/cracked player without a skin, the NPC wouldn't render. This fixes it by falling back to the NPC's own skin data if the viewer doesn't have one.

## ✅ Checklist

- [x] My code follows the project's coding style and guidelines
- [x] I have tested my changes locally and they work as expected
- [x] I have added necessary documentation (no documentation changes needed - bug fix)
- [x] I have rebased/merged with the latest `main` branch

## 🔍 Changes

- Added fallback to NPC's own skin data when viewer's profile lacks textures
- Ensures NPCs render correctly regardless of viewer's skin availability

## 🧪 How to Test

1. Create an NPC with `@mirror` skin setting
2. View it as an offline/cracked player (or test player without skin)
3. Verify the NPC renders with its own skin instead of disappearing
