### PR TITLE
Implement support for true/false permission requirements in FancyDialog

### DIFF
--- a/docs/src/fancydialogs/tutorials/json-schema.md
+++ b/docs/src/fancydialogs/tutorials/json-schema.md
@@ -105,6 +105,7 @@ Items will be supported in the body section in a future release.
 `requirements`: The requirement for this field to display
 - `type`: Either `permission` or `stringMatch`.
 - `permission`: If type is `permission`, this is the permission to check for.
+- `value`: If type is `permission`, whether the player should have the permission. `true` (default) requires the player to have the permission, `false` requires the player to NOT have it.
 - `input`: If type is `stringMatch`, this is the string being matched against `output`.
 - `output`: If type is `stringMatch`, this is the string being matched against `input`.
 
@@ -130,6 +131,7 @@ More input types will be added in future releases, such as checkboxes and number
 `requirements`: The requirement for this field to display
 - `type`: Either `permission` or `stringMatch`.
 - `permission`: If type is `permission`, this is the permission to check for.
+- `value`: If type is `permission`, whether the player should have the permission. `true` (default) requires the player to have the permission, `false` requires the player to NOT have it.
 - `input`: If type is `stringMatch`, this is the string being matched against `output`.
 - `output`: If type is `stringMatch`, this is the string being matched against `input`.
 
@@ -151,6 +153,7 @@ More input types will be added in future releases, such as checkboxes and number
 `requirements`: The requirement for this field to display
 - `type`: Either `permission` or `stringMatch`.
 - `permission`: If type is `permission`, this is the permission to check for.
+- `value`: If type is `permission`, whether the player should have the permission. `true` (default) requires the player to have the permission, `false` requires the player to NOT have it.
 - `input`: If type is `stringMatch`, this is the string being matched against `output`.
 - `output`: If type is `stringMatch`, this is the string being matched against `input`.
 
@@ -165,6 +168,7 @@ More input types will be added in future releases, such as checkboxes and number
 - `requirements`: The requirement for this field to display
   - `type`: Either `permission` or `stringMatch`.
   - `permission`: If type is `permission`, this is the permission to check for.
+  - `value`: If type is `permission`, whether the player should have the permission. `true` (default) requires the player to have the permission, `false` requires the player to NOT have it.
   - `input`: If type is `stringMatch`, this is the string being matched against `output`.
   - `output`: If type is `stringMatch`, this is the string being matched against `input`.
 

--- a/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/dialog/DialogImpl.java
+++ b/plugins/fancydialogs/src/main/java/com/fancyinnovations/fancydialogs/dialog/DialogImpl.java
@@ -54,21 +54,19 @@ public class DialogImpl extends Dialog {
         return result;
     }
 
-    private boolean checkPerm(Player player, String perm) {
-        if (perm == null) {
+    private boolean checkPerm(Player player, String perm, String valueStr) {
+        if (perm == null || perm.isEmpty()) {
             return true;
         }
-        if (!perm.equals("") && !player.hasPermission(perm)) {
-            return false;
-        }
-        return true;
+        boolean expectedValue = valueStr == null || Boolean.parseBoolean(valueStr);
+        return player.hasPermission(perm) == expectedValue;
     }
 
     private boolean checkRequirements(Player player, Map<String, String> requirements) {
         if (requirements == null) { return true; }
         if (requirements.get("type") == null) { return true; }
         if (requirements.get("type").equals("permission")) {
-            return checkPerm(player, requirements.get("permission"));
+            return checkPerm(player, requirements.get("permission"), requirements.get("value"));
         }
         if (requirements.get("type").equals("stringMatch")) {
             if (requirements.get("input") == null || requirements.get("output") == null) { return true; }


### PR DESCRIPTION
## 📋 Description

This PR adds support for configuring the expected value of a `permission` requirement in FancyDialog.

Previously, permission requirements always checked whether the player had the specified permission. This change adds an optional `value` field, allowing requirements to check whether a player **has** or **does not have** a permission.

If `value` is not specified, it defaults to `true`, preserving the existing behavior.

## 🔍 Changes

* Added an optional `value` field to `permission` requirements
* `value: true` requires the player to have the permission
* `value: false` requires the player to not have the permission
* Defaults to `true` when `value` is not specified
* Updated the permission requirement check to compare the player's permission status against the expected value

## 🧪 How to Test

1. Create a `permission` requirement without specifying `value`.
2. Verify it passes when the player has the required permission.
3. Set `value: true` and verify it still passes when the player has the permission.
4. Set `value: false` and verify it passes when the player does **not** have the permission.
5. Verify that `value: false` fails when the player **does** have the permission.
