### PR TITLE
fancynpcs: Fix legacy formatting in team names

### DIFF
--- a/plugins/fancynpcs-v2/fn-v2-api/src/main/java/de/oliver/fancynpcs/api/Npc.java
+++ b/plugins/fancynpcs-v2/fn-v2-api/src/main/java/de/oliver/fancynpcs/api/Npc.java
@@ -31,11 +31,13 @@ public abstract class Npc {
     protected final Map<UUID, Boolean> isLookingAtPlayer = new ConcurrentHashMap<>();
     protected final Map<UUID, Long> lastPlayerInteraction = new ConcurrentHashMap<>();
     private final Translator translator = FancyNpcsPlugin.get().getTranslator();
+    protected final String teamName;
     protected NpcData data;
     protected boolean saveToFile;
 
     public Npc(NpcData data) {
         this.data = data;
+        this.teamName = generateTeamName();
         this.saveToFile = true;
     }
 
@@ -46,6 +48,10 @@ public abstract class Npc {
         }
 
         return ChatColor.translateAlternateColorCodes('&', localName.toString());
+    }
+
+    protected String generateTeamName() {
+        return "npc-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
     }
 
     public abstract void create();

--- a/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/Npc_1_21_11.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_11/src/main/java/de/oliver/fancynpcs/v1_21_11/Npc_1_21_11.java
@@ -243,7 +243,7 @@ public class Npc_1_21_11 extends Npc {
 
         List<Packet<? super ClientGamePacketListener>> packets = new ArrayList<>();
 
-        PlayerTeam team = new PlayerTeam(new Scoreboard(), "npc-" + localName);
+        PlayerTeam team = new PlayerTeam(new Scoreboard(), teamName);
         team.getPlayers().clear();
         team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().name() : npc.getStringUUID());
         team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));

--- a/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/Npc_1_21_5.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_5/src/main/java/de/oliver/fancynpcs/v1_21_5/Npc_1_21_5.java
@@ -226,7 +226,7 @@ public class Npc_1_21_5 extends Npc {
 
         ServerPlayer serverPlayer = ((CraftPlayer) player).getHandle();
 
-        PlayerTeam team = new PlayerTeam(new Scoreboard(), "npc-" + localName);
+        PlayerTeam team = new PlayerTeam(new Scoreboard(), teamName);
         team.getPlayers().clear();
         team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().getName() : npc.getStringUUID());
         team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));

--- a/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/Npc_1_21_6.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_6/src/main/java/de/oliver/fancynpcs/v1_21_6/Npc_1_21_6.java
@@ -237,7 +237,7 @@ public class Npc_1_21_6 extends Npc {
 
         ServerPlayer serverPlayer = ((CraftPlayer) player).getHandle();
 
-        PlayerTeam team = new PlayerTeam(new Scoreboard(), "npc-" + localName);
+        PlayerTeam team = new PlayerTeam(new Scoreboard(), teamName);
         team.getPlayers().clear();
         team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().getName() : npc.getStringUUID());
         team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));

--- a/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/Npc_1_21_9.java
+++ b/plugins/fancynpcs-v2/implementation_1_21_9/src/main/java/de/oliver/fancynpcs/v1_21_9/Npc_1_21_9.java
@@ -243,7 +243,7 @@ public class Npc_1_21_9 extends Npc {
 
         List<Packet<? super ClientGamePacketListener>> packets = new ArrayList<>();
 
-        PlayerTeam team = new PlayerTeam(new Scoreboard(), "npc-" + localName);
+        PlayerTeam team = new PlayerTeam(new Scoreboard(), teamName);
         team.getPlayers().clear();
         team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().name() : npc.getStringUUID());
         team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));

--- a/plugins/fancynpcs-v2/implementation_26_1_2/src/main/java/de/oliver/fancynpcs/v26_1_1/Npc_26_1_1.java
+++ b/plugins/fancynpcs-v2/implementation_26_1_2/src/main/java/de/oliver/fancynpcs/v26_1_1/Npc_26_1_1.java
@@ -243,7 +243,7 @@ public class Npc_26_1_1 extends Npc {
 
         List<Packet<? super ClientGamePacketListener>> packets = new ArrayList<>();
 
-        PlayerTeam team = new PlayerTeam(new Scoreboard(), "npc-" + localName);
+        PlayerTeam team = new PlayerTeam(new Scoreboard(), teamName);
         team.getPlayers().clear();
         team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().name() : npc.getStringUUID());
         team.setColor(PaperAdventure.asVanilla(data.getGlowingColor()));

--- a/plugins/fancynpcs-v2/implementation_26_2/src/main/java/de/oliver/fancynpcs/v26_2/Npc_26_2.java
+++ b/plugins/fancynpcs-v2/implementation_26_2/src/main/java/de/oliver/fancynpcs/v26_2/Npc_26_2.java
@@ -243,7 +243,7 @@ public class Npc_26_2 extends Npc {
 
         List<Packet<? super ClientGamePacketListener>> packets = new ArrayList<>();
 
-        PlayerTeam team = new PlayerTeam(new Scoreboard(), "npc-" + localName);
+        PlayerTeam team = new PlayerTeam(new Scoreboard(), teamName);
         team.getPlayers().clear();
         team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().name() : npc.getStringUUID());
         team.setColor(Optional.of(PaperAdventure.asVanilla(data.getGlowingColor())));

--- a/plugins/fancynpcs-v2/implementation_26_3/src/main/java/de/oliver/fancynpcs/v26_3/Npc_26_3.java
+++ b/plugins/fancynpcs-v2/implementation_26_3/src/main/java/de/oliver/fancynpcs/v26_3/Npc_26_3.java
@@ -243,7 +243,7 @@ public class Npc_26_3 extends Npc {
 
         List<Packet<? super ClientGamePacketListener>> packets = new ArrayList<>();
 
-        PlayerTeam team = new PlayerTeam(new Scoreboard(), "npc-" + localName);
+        PlayerTeam team = new PlayerTeam(new Scoreboard(), teamName);
         team.getPlayers().clear();
         team.getPlayers().add(npc instanceof ServerPlayer npcPlayer ? npcPlayer.getGameProfile().name() : npc.getStringUUID());
         team.setColor(Optional.of(PaperAdventure.asVanilla(data.getGlowingColor())));


### PR DESCRIPTION
## Description

Fixes #290.

FancyNpcs generated hidden fake player names with legacy formatting codes and reused that same value as the scoreboard team identifier. This PR keeps the hidden local player name unchanged, but gives each NPC a separate plain ASCII team name before creating `PlayerTeam` packets.

## Checklist

- [x] My code follows the project's coding style and guidelines
- [x] I have tested my changes locally and they work as expected
- [x] I have added necessary documentation (if applicable)
- [x] I have linked related issues using `Fixes #290` or `Closes #290`
- [x] I have rebased/merged with the latest `main` branch

## Changes

- Added a separate `teamName` field to `Npc`, generated once per NPC instance.
- Replaced `"npc-" + localName` with the plain `teamName` in all active FancyNpcs v2 NMS implementations.
- Left `localName` unchanged for fake player/GameProfile names, so NPC name hiding behavior stays the same.

## Evidence

Buggy FancyNpcs 2.11.0 on Paper 1.21.11 with Nexo 1.25.1:

```text
[16:58:26] [Server thread/WARN]: [FancyNpcsLegacyTeamRepro] BUG REPRODUCED: FancyNpcs NPC class de.oliver.fancynpcs.v1_21_11.Npc_1_21_11 has no separate teamName field; team name is derived from legacy-coded localName.
```

Fixed jar with the same server/plugins:

```text
[17:08:00] [Server thread/INFO]: [FancyNpcsLegacyTeamRepro] FIX VERIFIED: FancyNpcs teamName is plain and separate from localName.
```

## How to Test

1. Start Paper 1.21.11 with FancyNpcs 2.11.0, Nexo 1.25.1, and a small repro plugin that creates a FancyNpcs API NPC.
2. With the buggy jar, run `/fnlegacyrepro npc` then `/fnlegacyrepro inspect`; the repro confirms the team name is derived from the legacy-coded `localName`.
3. With this fix applied, run `/fnlegacyrepro cleanup`, `/fnlegacyrepro npc`, then `/fnlegacyrepro inspect`.
4. Confirm the repro logs: `FIX VERIFIED: FancyNpcs teamName is plain and separate from localName.`

Local checks run:

- `rg -n -F '"npc-" + localName' plugins\fancynpcs-v2` returned no matches.
- `git diff --check` passed.
- `./gradlew.bat --no-daemon --console=plain :plugins:fancynpcs-v2:fn-v2-api:build` passed.
- Manual fixed-server verification passed on Paper 1.21.11 with Nexo 1.25.1.

Known local environment blocker:

- `./gradlew.bat --no-daemon --console=plain :plugins:fancynpcs-v2:shadowJar` and `./gradlew.bat --no-daemon --console=plain test` fail before this code compiles because Paper's 1.21.11 dev bundle resolves `net.kyori:adventure-text-serializer-ansi` without a version for `:libraries:packets:implementations:1_21_11:compileJava`.
